### PR TITLE
fix: 處理 PrimeVue 元件屬性未使用導致的 Vue Warn

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL='http://localhost:3000/api'

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -1,47 +1,49 @@
 <script setup>
-import Tabs from '@/volt/Tabs.vue'
-import TabList from '@/volt/TabList.vue'
-import Tab from '@/volt/Tab.vue'
-import TabPanels from '@/volt/TabPanels.vue'
-import TabPanel from '@/volt/TabPanel.vue'
-import DataTable from '@/volt/DataTable.vue'
-import Column from 'primevue/column'
-import { ref } from 'vue'
+  import Tabs from '@/volt/Tabs.vue'
+  import TabList from '@/volt/TabList.vue'
+  import Tab from '@/volt/Tab.vue'
+  import TabPanels from '@/volt/TabPanels.vue'
+  import TabPanel from '@/volt/TabPanel.vue'
+  import DataTable from '@/volt/DataTable.vue'
+  import Column from 'primevue/column'
+  import { ref } from 'vue'
 
-const selectedRows = ref([])
+  const selectedRows = ref([])
 
-function filteredData(status) {
-  if (status === 'all') {
-    return props.value
-  } else {
-    return props.value.filter((item) => item.status === status)
+  function filteredData(status) {
+    if (status === 'all') {
+      return props.value
+    } else {
+      return props.value.filter((item) => item.status === status)
+    }
   }
-}
 
-const props = defineProps({
-  tabs: {
-    type: Array,
-    required: true,
-  },
-  columns: {
-    type: Array,
-    required: true,
-  },
-  value: {
-    type: Array,
-    required: true,
-  },
-  scrollable: { type: Boolean, default: true },
-  scrollHeight: { type: String, default: '500px' },
-  selectable: { type: Boolean, default: true },
-})
+  const props = defineProps({
+    tabs: {
+      type: Array,
+      required: true,
+    },
+    columns: {
+      type: Array,
+      required: true,
+    },
+    value: {
+      type: Array,
+      required: true,
+    },
+    scrollable: { type: Boolean, default: true },
+    scrollHeight: { type: String, default: '500px' },
+    selectable: { type: Boolean, default: true },
+  })
 </script>
 
 <template>
   <div class="card">
     <Tabs :value="tabs[1].value">
       <TabList>
-        <Tab v-for="tab in tabs" :key="tab.title" :value="tab.value">{{ tab.title }}</Tab>
+        <Tab v-for="tab in tabs" :key="tab.title" :value="tab.value">
+          {{ tab.title }}
+        </Tab>
       </TabList>
       <TabPanels>
         <TabPanel v-for="tab in tabs" :key="tab.value" :value="tab.value">
@@ -50,12 +52,14 @@ const props = defineProps({
               v-model:selection="selectedRows"
               :value="filteredData(tab.value)"
               removable-sort
-              pt:table="min-w-200"
               data-key="id"
               scrollable
               scroll-height="500px"
             >
-              <Column selection-mode="multiple" header-style="width: 3rem"></Column>
+              <Column
+                selection-mode="multiple"
+                header-style="width: 3rem"
+              ></Column>
               <Column field="img" style="width: 25%"></Column>
               <Column
                 v-for="col in columns"

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -40,8 +40,8 @@
     :tabs="productTabs"
     :columns="productColumns"
     :value="productValue"
-    :scrollable
-    :selectable
-    :scroll-height
+    scrollable
+    selectable
+    scroll-height="500px"
   />
 </template>


### PR DESCRIPTION
### 變更內容
- 修正`AdminProducts.vue` 的 `CommonTable` props 傳遞寫法，已解決 Console 彈出的警告
- 為測試後台商品列表能成功 render 出資料庫商品資料，新增 `.env.template` 設定 API 路徑前綴


### 相關資源
- Issue: #13 

### 備註
- 若未連接資料庫商品表格（要有資料），還是會看到 Invalid prop 的警告，但前後端都有 run 起來就是正常乾淨的 console！