### PR TITLE
feat: 新增後台訂單列表切版

### DIFF
--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -60,7 +60,6 @@
                 selection-mode="multiple"
                 header-style="width: 3rem"
               ></Column>
-              <Column field="img" style="width: 25%"></Column>
               <Column
                 v-for="col in columns"
                 :key="col.field"

--- a/src/views/Admin/AdminOrders.vue
+++ b/src/views/Admin/AdminOrders.vue
@@ -1,3 +1,57 @@
+<script setup>
+  import { ref } from 'vue'
+  import CommonTable from '@/components/CommonTable.vue'
+
+  const orderTabs = ref([
+    { title: '全部', value: 'all' },
+    { title: '待付款', value: 'unpaid' },
+    { title: '待出貨', value: 'unshipped' },
+    { title: '已出貨', value: 'shipped' },
+    { title: '已完成', value: 'completed' },
+    { title: '已取消', value: 'cancelled' },
+  ])
+  const orderColumns = ref([
+    { field: 'orderNumber', header: '訂單編號', style: 'width: 12.5%' },
+    { field: 'date', header: '日期', style: 'width: 12.5%' },
+    { field: 'customer', header: '顧客', style: 'width: 12.5%' },
+    { field: 'payment', header: '付款狀態', style: 'width: 12.5%' },
+    { field: 'shipping', header: '物流狀態', style: 'width: 12.5%' },
+    { field: 'status', header: '訂單狀態', style: 'width: 12.5%' },
+    { field: 'total', header: '總金額', style: 'width: 12.5%' },
+    { field: 'quantity', header: '數量', style: 'width: 12.5%' },
+  ])
+  // 假資料
+  const orderValue = ref([
+    {
+      orderNumber: 'f230fh0g3',
+      date: '2024-06-25',
+      customer: 'John Doe',
+      payment: '已付款',
+      shipping: '已出貨',
+      status: '已完成',
+      total: '$100',
+      quantity: '1',
+    },
+  ])
+</script>
+
 <template>
-  <h2>這是後台訂單頁面</h2>
+  <div class="flex justify-between items-center mr-8 mb-4">
+    <h2 class="text-2xl">訂單</h2>
+    <div class="card flex justify-center">
+      <button
+        class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
+      >
+        新增訂單
+      </button>
+    </div>
+  </div>
+  <CommonTable
+    :tabs="orderTabs"
+    :columns="orderColumns"
+    :value="orderValue"
+    scrollable
+    selectable
+    scroll-height="500px"
+  />
 </template>

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -12,6 +12,7 @@
     { title: '典藏', value: 'archived' },
   ])
   const productColumns = ref([
+    { field: 'img', header: '商品圖', style: 'width: 25%' },
     { field: 'name', header: '商品', style: 'width: 25%' },
     { field: 'status', header: '狀態', style: 'width: 25%' },
     { field: 'currentStock', header: '庫存數量', style: 'width: 25%' },


### PR DESCRIPTION
### 變更內容
- 用 `CommonTable` 新增了後台訂單列表
- Tab切換尚未實作

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/6fa89fbe-5f6c-4037-a99c-f42d04be54bf" />


### 相關資源
- Issue: #16 

### 備註
- 此 PR 分支從 #15 切出來，要先合併 15 再合併這個 PR
- 新增資料庫訂單Table後，會再回來完成Tab切換邏輯