### PR TITLE
feat: 新增後台庫存列表

### DIFF
--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -39,7 +39,7 @@
 
 <template>
   <div class="card">
-    <Tabs :value="tabs[1].value">
+    <Tabs :value="tabs[0].value">
       <TabList>
         <Tab v-for="tab in tabs" :key="tab.title" :value="tab.value">
           {{ tab.title }}
@@ -65,7 +65,7 @@
                 :key="col.field"
                 :field="col.field"
                 :header="col.header"
-                sortable
+                :sortable="col.sortable"
                 :style="col.style"
               ></Column>
             </DataTable>

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -67,7 +67,13 @@
                 :header="col.header"
                 :sortable="col.sortable"
                 :style="col.style"
-              ></Column>
+              >
+                <template #body="slotProps">
+                  <slot :name="`body-${col.field}`" :data="slotProps.data">
+                    {{ slotProps.data[col.field] }}
+                  </slot>
+                </template>
+              </Column>
             </DataTable>
           </div>
         </TabPanel>

--- a/src/components/EditableTable.vue
+++ b/src/components/EditableTable.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="card">
+    <DataTable
+      :value="products"
+      editMode="cell"
+      @cell-edit-complete="onCellEditComplete"
+      :pt="{
+        table: { style: 'min-width: 50rem' },
+        column: {
+          bodycell: ({ state }) => ({
+            class: [{ '!py-0': state['d_editing'] }],
+          }),
+        },
+      }"
+    >
+      <Column
+        v-for="col of columns"
+        :key="col.field"
+        :field="col.field"
+        :header="col.header"
+        style="width: 25%"
+      >
+        <template #body="{ data, field }">
+          {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
+        </template>
+        <template #editor="{ data, field }">
+          <template v-if="field !== 'price'">
+            <InputText v-model="data[field]" autofocus fluid />
+          </template>
+          <template v-else>
+            <InputNumber
+              v-model="data[field]"
+              mode="currency"
+              currency="USD"
+              locale="en-US"
+              autofocus
+              fluid
+            />
+          </template>
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>
+
+<script setup>
+  import { ref, onMounted } from 'vue'
+  import { ProductService } from '@/service/ProductService'
+
+  const products = ref()
+  const columns = ref([
+    { field: 'code', header: 'Code' },
+    { field: 'name', header: 'Name' },
+    { field: 'quantity', header: 'Quantity' },
+    { field: 'price', header: 'Price' },
+  ])
+
+  onMounted(() => {
+    ProductService.getProductsMini().then((data) => (products.value = data))
+  })
+
+  const onCellEditComplete = (event) => {
+    let { data, newValue, field } = event
+
+    switch (field) {
+      case 'quantity':
+      case 'price':
+        if (isPositiveInteger(newValue)) data[field] = newValue
+        else event.preventDefault()
+        break
+
+      default:
+        if (newValue.trim().length > 0) data[field] = newValue
+        else event.preventDefault()
+        break
+    }
+  }
+  const isPositiveInteger = (val) => {
+    let str = String(val)
+
+    str = str.trim()
+
+    if (!str) {
+      return false
+    }
+
+    str = str.replace(/^0+/, '') || '0'
+    var n = Math.floor(Number(str))
+
+    return n !== Infinity && String(n) === str && n >= 0
+  }
+  const formatCurrency = (value) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(value)
+  }
+</script>

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -1,5 +1,6 @@
 <script setup>
   import CommonTable from '@/components/CommonTable.vue'
+  import InputText from 'primevue/inputtext'
   import { ref } from 'vue'
 
   const inventoryTabs = ref([{ title: '全部', value: 'all' }])
@@ -40,5 +41,13 @@
     scrollable
     selectable
     scroll-height="500px"
-  />
+  >
+    <template #body-reserved="{ data }">
+      <InputText v-model="data.reserved" class="w-full" />
+    </template>
+
+    <template #body-stockOnHand="{ data }">
+      <InputText v-model="data.stockOnHand" class="w-full" />
+    </template>
+  </CommonTable>
 </template>

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -1,35 +1,44 @@
 <script setup>
   import CommonTable from '@/components/CommonTable.vue'
   import { ref } from 'vue'
-  const inventoryTabs = ref([
-    { title: '全部', content: 'Tab 1 Content', value: 'all' },
-    { title: '上架中', content: 'Tab 1 Content', value: 'active' },
-    { title: '草稿', content: 'Tab 2 Content', value: 'draft' },
-    { title: '典藏', content: 'Tab 3 Content', value: 'archived' },
-  ])
+
+  const inventoryTabs = ref([{ title: '全部', value: 'all' }])
   const inventoryColumns = ref([
-    { field: 'name', header: '商品', style: 'width: 25%' },
-    { field: 'status', header: '狀態', style: 'width: 25%' },
-    { field: 'stock', header: '庫存數量', style: 'width: 25%' },
+    { field: 'img', header: '', style: 'width: 25%', sortable: false },
+    { field: 'name', header: '商品', style: 'width: 25%', sortable: true },
+    {
+      field: 'reserved',
+      header: '預留數量',
+      style: 'width: 25%',
+      sortable: true,
+    },
+    {
+      field: 'stockOnHand',
+      header: '現有庫存',
+      style: 'width: 25%',
+      sortable: true,
+    },
   ])
   const inventoryValue = ref([
     {
       img: 'f230fh0g3',
-      name: 'Bamboo Watch',
-      status: 'Accessories',
-      stock: 24,
+      name: '路卡力歐',
+      reserved: 2,
+      stockOnHand: 24,
     },
   ])
 </script>
 
 <template>
-  <h2 class="mb-4 text-2xl">庫存</h2>
+  <div class="flex justify-between items-center mr-8 mb-4">
+    <h2 class="text-2xl">庫存</h2>
+  </div>
   <CommonTable
     :tabs="inventoryTabs"
     :columns="inventoryColumns"
     :value="inventoryValue"
-    :scrollable
-    :selectable
-    :scroll-height
+    scrollable
+    selectable
+    scroll-height="500px"
   />
 </template>

--- a/src/views/Admin/AdminOrders.vue
+++ b/src/views/Admin/AdminOrders.vue
@@ -11,14 +11,44 @@
     { title: '已取消', value: 'cancelled' },
   ])
   const orderColumns = ref([
-    { field: 'orderNumber', header: '訂單編號', style: 'width: 12.5%' },
-    { field: 'date', header: '日期', style: 'width: 12.5%' },
-    { field: 'customer', header: '顧客', style: 'width: 12.5%' },
-    { field: 'payment', header: '付款狀態', style: 'width: 12.5%' },
-    { field: 'shipping', header: '物流狀態', style: 'width: 12.5%' },
-    { field: 'status', header: '訂單狀態', style: 'width: 12.5%' },
-    { field: 'total', header: '總金額', style: 'width: 12.5%' },
-    { field: 'quantity', header: '數量', style: 'width: 12.5%' },
+    {
+      field: 'orderNumber',
+      header: '訂單編號',
+      style: 'width: 12.5%',
+      sortable: true,
+    },
+    { field: 'date', header: '日期', style: 'width: 12.5%', sortable: true },
+    {
+      field: 'customer',
+      header: '顧客',
+      style: 'width: 12.5%',
+      sortable: false,
+    },
+    {
+      field: 'payment',
+      header: '付款狀態',
+      style: 'width: 12.5%',
+      sortable: true,
+    },
+    {
+      field: 'shipping',
+      header: '物流狀態',
+      style: 'width: 12.5%',
+      sortable: true,
+    },
+    {
+      field: 'status',
+      header: '訂單狀態',
+      style: 'width: 12.5%',
+      sortable: true,
+    },
+    { field: 'total', header: '總金額', style: 'width: 12.5%', sortable: true },
+    {
+      field: 'quantity',
+      header: '數量',
+      style: 'width: 12.5%',
+      sortable: true,
+    },
   ])
   // 假資料
   const orderValue = ref([

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -1,8 +1,8 @@
 <script setup>
   import { ref } from 'vue'
   import CommonTable from '@/components/CommonTable.vue'
-  import { fetchAllProducts } from '@/api/admin/product'
-  import { onMounted } from 'vue'
+  // import { fetchAllProducts } from '@/api/admin/product'
+  // import { onMounted } from 'vue'
   import { useRouter } from 'vue-router'
   const router = useRouter()
   const productTabs = ref([
@@ -12,17 +12,29 @@
     { title: '典藏', value: 'archived' },
   ])
   const productColumns = ref([
-    { field: 'img', header: '商品圖', style: 'width: 25%' },
-    { field: 'name', header: '商品', style: 'width: 25%' },
-    { field: 'status', header: '狀態', style: 'width: 25%' },
-    { field: 'currentStock', header: '庫存數量', style: 'width: 25%' },
+    { field: 'img', header: '', style: 'width: 25%', sortable: false },
+    { field: 'name', header: '商品', style: 'width: 25%', sortable: true },
+    { field: 'status', header: '狀態', style: 'width: 25%', sortable: true },
+    {
+      field: 'currentStock',
+      header: '庫存數量',
+      style: 'width: 25%',
+      sortable: true,
+    },
   ])
 
-  const productValue = ref([])
-  onMounted(async () => {
-    const res = await fetchAllProducts()
-    productValue.value = res
-  })
+  const productValue = ref([
+    {
+      img: 'f230fh0g3',
+      name: '路卡力歐',
+      status: '上架中',
+      currentStock: 24,
+    },
+  ])
+  // onMounted(async () => {
+  //   const res = await fetchAllProducts()
+  //   productValue.value = res
+  // })
 </script>
 
 <template>


### PR DESCRIPTION
### 變更內容
- 新增後台庫存列表
- 欄位有商品縮圖、商品名稱、預留數量（被訂單佔用但未出貨的數量）、實際庫存
- 庫存可以直接在列表修改

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3e56b86c-e9dd-401c-98a8-20bbc6a29de8" />


### 相關資源
- Issue: #18 

### 備註
- 下一步：若有庫存輸入框內容有被修改過，就會跳出儲存編輯的按鈕，按下之後再更新資料庫的商品庫存表＆庫存記錄表