### PR TITLE
feat: 新增導覽列與頁尾元件（Navbar & Footer）

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,14 @@
 <script setup>
-  import { RouterLink, RouterView } from 'vue-router'
+import Navbar from '@/components/layout/NavBar.vue'
+import Footer from '@/components/layout/Footer.vue'
 </script>
 
 <template>
-  <nav class="p-4 bg-gray-100 mb-4">
-    <RouterLink to="/admin" class="mr-4">後台首頁</RouterLink>
-    <RouterLink to="/">首頁</RouterLink>
-    <RouterLink to="/productdetailpage" class="ml-4">Product</RouterLink>
-  </nav>
+  <Navbar />
 
+  <main class="mt-6 bg-gray-50 min-h-screen">
   <RouterView />
+  </main>
+
+  <Footer />
 </template>

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -1,0 +1,13 @@
+<template>
+  <footer class="w-full bg-gray-100 text-center text-sm py-2 shadow mt-10">
+    <span class="text-gray-600">© 2025 WanPai. All rights reserved.</span>
+    <div class="flex justify-center gap-4 mt-2 flex-wrap">
+      <a href="#" class="hover:underline">隱私權政策</a>
+      <a href="#" class="hover:underline">使用條款</a>
+      <a href="#" class="hover:underline">聯絡我們</a>
+    </div>
+  </footer>
+</template>
+
+<script setup>
+</script>

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -1,3 +1,7 @@
+<script setup>
+
+</script>
+
 <template>
   <footer class="w-full bg-gray-100 text-center text-sm py-2 shadow mt-10">
     <span class="text-gray-600">© 2025 WanPai. All rights reserved.</span>
@@ -9,5 +13,3 @@
   </footer>
 </template>
 
-<script setup>
-</script>

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -1,3 +1,19 @@
+<script setup>
+import { ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import Drawer from 'primevue/drawer'
+import Button from 'primevue/button'
+
+const visible = ref(false)
+
+const menuItems = [
+  { label: '後台首頁', to: '/admin' },
+  { label: '首頁', to: '/' },
+  { label: '商品詳情', to: '/productdetailpage' },
+]
+</script>
+
+
 <template>
   <header class="bg-white shadow-sm">
     <div class="max-w-screen-xl mx-auto flex items-center justify-between h-16 px-6">
@@ -30,7 +46,7 @@
     </div>
 
 
-    <Sidebar v-model:visible="visible" position="right">
+    <Drawer v-model:visible="visible" position="right">
       <template #header>
         <div class="text-lg font-semibold">選單</div>
       </template>
@@ -46,21 +62,7 @@
         </RouterLink>
         <Button label="登入" severity="primary" class="mt-4" @click="visible = false" />
       </div>
-    </Sidebar>
+    </Drawer>
   </header>
 </template>
 
-<script setup>
-import { ref } from 'vue'
-import { RouterLink } from 'vue-router'
-import Sidebar from 'primevue/sidebar'
-import Button from 'primevue/button'
-
-const visible = ref(false)
-
-const menuItems = [
-  { label: '後台首頁', to: '/admin' },
-  { label: '首頁', to: '/' },
-  { label: '商品詳情', to: '/productdetailpage' },
-]
-</script>

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -1,0 +1,66 @@
+<template>
+  <header class="bg-white shadow-sm">
+    <div class="max-w-screen-xl mx-auto flex items-center justify-between h-16 px-6">
+
+      <RouterLink to="/" class="text-xl font-bold text-emerald-600">
+        Wanpai
+      </RouterLink>
+
+
+      <nav class="hidden md:flex gap-8 text-sm text-gray-700 font-medium">
+        <RouterLink
+          v-for="item in menuItems"
+          :key="item.label"
+          :to="item.to"
+          class="hover:text-emerald-600 transition"
+        >
+          {{ item.label }}
+        </RouterLink>
+      </nav>
+
+
+      <div class="hidden md:block">
+        <Button label="登入" severity="primary" size="small" />
+      </div>
+
+
+      <div class="md:hidden">
+        <Button icon="pi pi-bars" text @click="visible = true" />
+      </div>
+    </div>
+
+
+    <Sidebar v-model:visible="visible" position="right">
+      <template #header>
+        <div class="text-lg font-semibold">選單</div>
+      </template>
+      <div class="flex flex-col gap-5 mt-4 px-4">
+        <RouterLink
+          v-for="item in menuItems"
+          :key="item.label"
+          :to="item.to"
+          class="text-gray-800 hover:text-emerald-600 text-base font-medium"
+          @click="visible = false"
+        >
+          {{ item.label }}
+        </RouterLink>
+        <Button label="登入" severity="primary" class="mt-4" @click="visible = false" />
+      </div>
+    </Sidebar>
+  </header>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import Sidebar from 'primevue/sidebar'
+import Button from 'primevue/button'
+
+const visible = ref(false)
+
+const menuItems = [
+  { label: '後台首頁', to: '/admin' },
+  { label: '首頁', to: '/' },
+  { label: '商品詳情', to: '/productdetailpage' },
+]
+</script>


### PR DESCRIPTION
### 功能描述

新增網站導覽列（Navbar）與頁尾（Footer）元件，使用 PrimeVue 元件並支援響應式設計。

### 主要內容

- 使用 `Menubar`、`Drawer`、`Button` 等 PrimeVue 元件構建導覽列。
- 桌面版顯示橫向導覽列，手機版自動切換為漢堡選單與側邊欄。
- 頁尾顯示版權資訊與常見連結，支援 RWD。
- 加入基礎導覽項目：首頁、商品瀏覽、關於我們。
![image](https://github.com/user-attachments/assets/b505892c-a95d-42c4-b589-c546e3395234)
![image](https://github.com/user-attachments/assets/b0b1291f-ecdf-486e-b239-a184c315f1bf)


### 使用技術

- PrimeVue + Tailwind CSS
- Vue Router（透過 `RouterLink` 導頁）

### 待辦事項

- 目前只是簡單的navbar跟footer 後續要增加要等待其他頁面做完才能做連結
- 並在討論專案需要甚麼後再優化新增
- 如果有其他可以先做的我沒想到的再麻煩大家給點建議 謝謝

---
close #28 
