### PR TITLE
feat: 完成新增商品 API 

### DIFF
--- a/src/api/admin/product.js
+++ b/src/api/admin/product.js
@@ -1,6 +1,6 @@
 import axios from '@/utils/axiosInstance'
 
-export const fetchAllProducts = async () => {
+const fetchAllProducts = async () => {
   try {
     const res = await axios.get('/admin/products')
     return res.data
@@ -9,3 +9,14 @@ export const fetchAllProducts = async () => {
     return err
   }
 }
+
+const createProduct = async (data) => {
+  try {
+    const res = await axios.post('/admin/products', data)
+    return res
+  } catch (err) {
+    return err
+  }
+}
+
+export { fetchAllProducts, createProduct }

--- a/src/components/ProductForm.vue
+++ b/src/components/ProductForm.vue
@@ -1,74 +1,158 @@
 <script setup>
   import { ref } from 'vue'
   import UploadFile from './UploadFile.vue'
-
   import AutoComplete from 'primevue/autocomplete'
   import Select from 'primevue/select'
+  import { createProduct } from '@/api/admin/product'
   const selectedType = ref()
   const types = ref([
     { name: 'ip', code: 'ip' },
     { name: '系列', code: 'siries' },
     { name: '品牌', code: 'brand' },
   ])
-  const value = ref(null)
+  const tagValue = ref(null)
   const items = ref([])
   // 商品標籤選擇 WIP
   const search = (event) => {
     items.value = [...Array(10).keys()].map((item) => event.query + '-' + item)
   }
+  const statusOptions = ref([
+    { name: '草稿', value: 'draft' },
+    { name: '上架中', value: 'active' },
+    { name: '典藏', value: 'archived' },
+  ])
+  const form = ref({
+    name: '',
+    sku: '',
+    description: '',
+    price: 0,
+    stockOnHand: 0,
+    status: 'draft',
+  })
+
+  const submit = async () => {
+    if (!form.value.name) {
+      alert('請輸入商品名稱')
+      return
+    }
+    if (!form.value.sku) {
+      alert('請輸入商品貨號')
+      return
+    }
+    if (!form.value.description) {
+      alert('請輸入商品描述')
+      return
+    }
+    try {
+      await createProduct({ ...form.value })
+      // 新增成功 dialog
+    } catch (err) {
+      return err
+      // 新增失敗 dialog
+    }
+  }
 </script>
 
 <template>
-  <label class="block" for="title">商品名稱</label>
-  <input
-    type="text"
-    id="title"
-    class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
-  />
-  <label class="block" for="description">商品描述</label>
-  <textarea
-    class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200 resize-none"
-    name="description"
-    id="description"
-  ></textarea>
-  <label class="block" for="image">商品圖片</label>
-  <UploadFile />
+  <div class="flex flex-col gap-4 mt-4">
+    <div>
+      <label class="font-bold mb-2 block" for="title">商品名稱</label>
+      <input
+        v-model="form.name"
+        type="text"
+        id="title"
+        class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
+      />
+    </div>
 
-  <label class="block" for="price">商品價格</label>
-  <input
-    type="number"
-    id="price"
-    min="0"
-    class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
-  />
-  <!-- Tag type selector -->
+    <div>
+      <label class="font-bold mb-2 block" for="sku">商品貨號</label>
+      <input
+        v-model="form.sku"
+        type="text"
+        id="sku"
+        class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
+      />
+    </div>
 
-  <label class="block" for="stock">目前庫存數</label>
-  <input
-    type="number"
-    id="stock"
-    min="0"
-    class="block bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
-  />
+    <div>
+      <label class="font-bold mb-2 block" for="description">商品描述</label>
+      <textarea
+        v-model="form.description"
+        class="w-240 h-80 bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200 resize-none"
+        name="description"
+        id="description"
+      ></textarea>
+    </div>
 
-  <Select
-    v-model="selectedType"
-    :options="types"
-    optionLabel="name"
-    placeholder="選擇標籤類型"
-    class="w-full md:w-56"
-  />
-  <label for="multiple-ac-2" class="font-bold mt-8 mb-2 block">商品標籤</label>
+    <div>
+      <label class="font-bold mb-2 block" for="image">商品圖片</label>
+      <UploadFile />
+    </div>
 
-  <AutoComplete
-    v-model="value"
-    inputId="multiple-ac-2"
-    multiple
-    fluid
-    :typeahead="false"
-    :suggestions="items"
-    field="name"
-    @complete="search"
-    @customItem="handleCustomTag"
-  />
+    <div>
+      <label class="font-bold mb-2 block" for="price">商品價格</label>
+      <input
+        v-model="form.price"
+        type="number"
+        id="price"
+        min="0"
+        class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
+      />
+    </div>
+
+    <div>
+      <label class="font-bold mb-2 block" for="stock">目前庫存數</label>
+      <input
+        v-model="form.stockOnHand"
+        type="number"
+        id="stock"
+        min="0"
+        class="block bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary px-3 py-2 transition-colors duration-200"
+      />
+    </div>
+
+    <div>
+      <label for="multiple-ac-2" class="font-bold mb-2 block">商品標籤</label>
+      <div class="flex gap-4">
+        <Select
+          v-model="selectedType"
+          :options="types"
+          optionLabel="name"
+          placeholder="選擇標籤類型"
+          class="w-full md:w-56"
+        />
+        <AutoComplete
+          v-model="tagValue"
+          inputId="multiple-ac-2"
+          multiple
+          fluid
+          :typeahead="false"
+          :suggestions="items"
+          field="name"
+          @complete="search"
+        />
+      </div>
+    </div>
+    <div>
+      <label class="font-bold mb-2 block" for="status">商品狀態</label>
+      <Select
+        v-model="form.status"
+        :options="statusOptions"
+        optionLabel="name"
+        optionValue="value"
+        placeholder="選擇商品狀態"
+        class="w-full md:w-56"
+      />
+    </div>
+
+    <div>
+      <button
+        class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
+        @click="submit"
+      >
+        <slot>儲存商品</slot>
+      </button>
+    </div>
+  </div>
 </template>

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -24,12 +24,14 @@
 
 <template>
   <h2 class="mb-4 text-2xl">庫存</h2>
-  <CommonTable
-    :tabs="inventoryTabs"
-    :columns="inventoryColumns"
-    :value="inventoryValue"
-    :scrollable
-    :selectable
-    :scroll-height
-  />
+  <div class="mr-8">
+    <CommonTable
+      :tabs="inventoryTabs"
+      :columns="inventoryColumns"
+      :value="inventoryValue"
+      :scrollable
+      :selectable
+      :scroll-height
+    />
+  </div>
 </template>

--- a/src/views/Admin/AdminOrders.vue
+++ b/src/views/Admin/AdminOrders.vue
@@ -46,12 +46,14 @@
       </button>
     </div>
   </div>
-  <CommonTable
-    :tabs="orderTabs"
-    :columns="orderColumns"
-    :value="orderValue"
-    scrollable
-    selectable
-    scroll-height="500px"
-  />
+  <div class="mr-8">
+    <CommonTable
+      :tabs="orderTabs"
+      :columns="orderColumns"
+      :value="orderValue"
+      scrollable
+      selectable
+      scroll-height="500px"
+    />
+  </div>
 </template>

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -37,12 +37,14 @@
       </button>
     </div>
   </div>
-  <CommonTable
-    :tabs="productTabs"
-    :columns="productColumns"
-    :value="productValue"
-    scrollable
-    selectable
-    scroll-height="500px"
-  />
+  <div class="mr-8">
+    <CommonTable
+      :tabs="productTabs"
+      :columns="productColumns"
+      :value="productValue"
+      scrollable
+      selectable
+      scroll-height="500px"
+    />
+  </div>
 </template>


### PR DESCRIPTION
### 變更內容
- 新增商品功能完成
- 商品編輯頁切版新增貨號與商品狀態 Input
- 填寫必要欄位後，按下儲存商品按鈕，會打 createProduct 這支 API，存商品資料到後端

### 驗證方式
後端：
1. 等待後端的 PR18 合併 （修正中，完成會回來編輯PR並提醒reviewers）
2. 後端測試時可以先刪除 drizzle 資料夾
3.  `npm run generate`
4.  `npm run migrate`
5. `npm run dev` 

前端：
1. `npm run dev`
2. 在後台商品頁面點擊新增商品按鈕
3. 輸入必要欄位（圖片、標籤先不填寫）按下儲存商品
4. 確認資料庫Product Table是否更新成功

### 相關資源
- Issue: #27 

### 續開 Issue
- API 補上錯誤處理、成功後跳轉頁面、必填 toast 提醒
- 修理圖片上傳框爆版