### PR TITLE
Feat:完成登入註冊頁面切版

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import Footer from '@/components/layout/Footer.vue'
 
 <template>
   <Navbar />
-
+  
   <main class="mt-6 bg-gray-50 min-h-screen">
   <RouterView />
   </main>

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -36,7 +36,9 @@ const menuItems = [
 
 
       <div class="hidden md:block">
-        <Button label="登入" severity="primary" size="small" />
+        <RouterLink to="/loginsignup">
+         <Button label="登入" severity="primary" size="small" />
+        </RouterLink>
       </div>
 
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import ProductDetailPage from '../components/ProductDetailPage.vue'
 import CartView from '@/views/CartView.vue'
 import HomeView from '@/views/HomeView.vue'
+import LoginSignup from '@/views/ LoginSignup.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -68,6 +69,11 @@ const router = createRouter({
       name: 'Orders',
       component: () => import('@/views/OrderManagement.vue')
     }
+    {
+      path: '/loginsignup',
+      name: 'loginsignup',
+      component: LoginSignup,
+    },
   ],
 })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -68,7 +68,7 @@ const router = createRouter({
       path: '/orders',
       name: 'Orders',
       component: () => import('@/views/OrderManagement.vue')
-    }
+    },
     {
       path: '/loginsignup',
       name: 'loginsignup',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import ProductDetailPage from '../components/ProductDetailPage.vue'
 import CartView from '@/views/CartView.vue'
 import HomeView from '@/views/HomeView.vue'
-import LoginSignup from '@/views/ LoginSignup.vue'
+import LoginSignup from '@/views/LoginSignup.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -67,7 +67,7 @@ const router = createRouter({
     {
       path: '/orders',
       name: 'Orders',
-      component: () => import('@/views/OrderManagement.vue')
+      component: () => import('@/views/OrderManagement.vue'),
     },
     {
       path: '/loginsignup',

--- a/src/views/ LoginSignup.vue
+++ b/src/views/ LoginSignup.vue
@@ -1,0 +1,130 @@
+<script setup>
+  import { ref } from 'vue'
+  import Button from 'primevue/button'
+
+  const isLogin = ref(true)
+  const username = ref('')
+  const email = ref('')
+  const password = ref('')
+  const errorMessage = ref('')
+  const isPasswordVisible = ref(false)
+
+  const togglePasswordVisibility = () => {
+    isPasswordVisible.value = !isPasswordVisible.value
+  }
+
+  const toggleForm = () => {
+    isLogin.value = !isLogin.value
+  }
+
+  const onSubmit = () => {
+    errorMessage.value = ''
+
+    if (isLogin.value) {
+      if (!email.value || !password.value) {
+        errorMessage.value = '請填寫所有欄位'
+        return
+      }
+    } else {
+      if (!username.value || !email.value || !password.value) {
+        errorMessage.value = '請填寫所有欄位'
+        return
+      }
+    }
+  }
+</script>
+
+<template>
+  <div class="flex justify-center items-center min-h-screen bg-gray-100">
+    <div class="w-full max-w-md p-6 bg-white rounded-lg shadow-lg">
+      <h2 class="text-center text-2xl font-semibold mb-6">
+        {{ isLogin ? '登入' : '註冊' }}
+      </h2>
+
+      <div v-if="errorMessage" class="text-red-600 text-center mb-4">
+        <p>{{ errorMessage }}</p>
+      </div>
+
+      <form @submit.prevent="onSubmit">
+        <div v-if="!isLogin" class="mb-4">
+          <label for="username" class="block text-sm font-medium text-gray-700">
+            用戶名
+          </label>
+          <input
+            type="text"
+            id="username"
+            v-model="username"
+            class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="請輸入用戶名"
+            required
+          />
+        </div>
+
+        <div class="mb-4">
+          <label for="email" class="block text-sm font-medium text-gray-700">
+            電子郵件
+          </label>
+          <input
+            type="email"
+            id="email"
+            v-model="email"
+            class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="請輸入電子郵件"
+            required
+          />
+        </div>
+
+        <div class="mb-4 relative">
+          <label for="password" class="block text-sm font-medium text-gray-700">
+            密碼
+          </label>
+          <input
+            :type="isPasswordVisible ? 'text' : 'password'"
+            v-model="password"
+            id="password"
+            class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="請輸入密碼"
+            required
+          />
+          <button
+            type="button"
+            @click="togglePasswordVisibility"
+            class="absolute right-2 top-1/2 transform -translate-y"
+          >
+            <i
+              v-if="isPasswordVisible"
+              class="pi pi-eye-slash text-gray-500"
+            ></i>
+            <i v-else class="pi pi-eye text-gray-500"></i>
+          </button>
+        </div>
+
+        <div class="mb-6">
+          <Button v-if="isLogin" label="登入" class="w-full" type="submit" />
+        </div>
+        <div class="mb-6">
+          <Button
+            v-if="!isLogin"
+            label="建立帳戶"
+            class="w-full"
+            type="submit"
+          />
+        </div>
+      </form>
+      <div class="text-center">
+        <p class="text-sm text-gray-600">
+          {{ isLogin ? '還沒有帳戶？' : '已經有帳戶？' }}
+          <button @click="toggleForm" class="text-blue-600 hover:underline">
+            {{ isLogin ? '註冊' : '登入' }}
+          </button>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .password-input {
+    position: relative;
+  }
+</style>

--- a/src/views/LoginSignup.vue
+++ b/src/views/LoginSignup.vue
@@ -36,7 +36,7 @@
 
 <template>
   <div class="flex justify-center items-center min-h-screen bg-gray-100">
-    <div class="w-full max-w-md p-6 bg-white rounded-lg shadow-lg">
+    <div class="w-full max-w-md p-6 bg-white rounded-lg shadow-lg mt-[-100px]">
       <h2 class="text-center text-2xl font-semibold mb-6">
         {{ isLogin ? '登入' : '註冊' }}
       </h2>


### PR DESCRIPTION
### **變更內容**

- 新增登入註冊頁面
- 使用者可以在同一頁面中切換登入和註冊表單
- 密碼顯示/隱藏功能

### **驗證方式**
npm run dev
首頁點選登入
<img width="1438" alt="截圖 2025-06-06 下午4 32 07" src="https://github.com/user-attachments/assets/da652128-a88f-4962-9f0b-9826ae2be9d9" />
<img width="1440" alt="截圖 2025-06-06 下午4 31 57" src="https://github.com/user-attachments/assets/96831bfa-e38d-4338-8774-9c8340eef8f0" />


### 相關資源
[Issue: https://github.com/wanpai-app/frontend/issues/27](https://github.com/wanpai-app/frontend/issues/29)

