### PR TITLE
feat: 優化navbar、新增購物車icon

### DIFF
--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -1,53 +1,76 @@
 <script setup>
-import { ref } from 'vue'
-import { RouterLink } from 'vue-router'
-import Drawer from 'primevue/drawer'
-import Button from 'primevue/button'
+  import { ref } from 'vue'
+  import { RouterLink, useRoute } from 'vue-router'
+  import Drawer from 'primevue/drawer'
+  import Button from 'primevue/button'
+  import { useCartStore } from '@/stores/cart'
 
-const visible = ref(false)
+  const visible = ref(false)
+  const cart = useCartStore()
+  const route = useRoute()
 
-const menuItems = [
-  { label: '後台首頁', to: '/admin' },
-  { label: '首頁', to: '/' },
-  { label: '商品詳情', to: '/productdetailpage' },
-]
+  const menuItems = [{ label: '後台首頁', to: '/admin' }]
+
+  function handleHomeClick(e) {
+    if (route.path === '/') {
+      e.preventDefault()
+      window.location.reload()
+    }
+  }
 </script>
-
 
 <template>
   <header class="bg-white shadow-sm">
-    <div class="max-w-screen-xl mx-auto flex items-center justify-between h-16 px-6">
-
-      <RouterLink to="/" class="text-xl font-bold text-emerald-600">
+    <div
+      class="max-w-screen-xl mx-auto flex items-center justify-between h-16 px-6"
+    >
+      <!-- Logo -->
+      <RouterLink
+        to="/"
+        class="text-xl font-bold text-emerald-600"
+        @click="handleHomeClick"
+      >
         Wanpai
       </RouterLink>
 
-
+      <!-- 導覽連結 (桌機) -->
       <nav class="hidden md:flex gap-8 text-sm text-gray-700 font-medium">
         <RouterLink
           v-for="item in menuItems"
           :key="item.label"
           :to="item.to"
+          @click="item.to === '/' ? handleHomeClick($event) : null"
           class="hover:text-emerald-600 transition"
         >
           {{ item.label }}
         </RouterLink>
       </nav>
 
-
-      <div class="hidden md:block">
+      <!-- 桌機版購物車 + 登入 -->
+      <div class="hidden md:flex items-center gap-4">
+        <RouterLink to="/cart" class="relative">
+          <div class="relative">
+            <Button icon="pi pi-shopping-cart" text rounded />
+            <span
+              v-if="cart.items.length"
+              class="absolute -top-2 -right-2 bg-red-500 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center"
+            >
+              {{ cart.items.length }}
+            </span>
+          </div>
+        </RouterLink>
         <RouterLink to="/loginsignup">
-         <Button label="登入" severity="primary" size="small" />
+          <Button label="登入" severity="primary" size="small"></Button>
         </RouterLink>
       </div>
 
-
+      <!-- 手機版漢堡按鈕 -->
       <div class="md:hidden">
         <Button icon="pi pi-bars" text @click="visible = true" />
       </div>
     </div>
 
-
+    <!-- Drawer 手機選單 -->
     <Drawer v-model:visible="visible" position="right">
       <template #header>
         <div class="text-lg font-semibold">選單</div>
@@ -57,14 +80,38 @@ const menuItems = [
           v-for="item in menuItems"
           :key="item.label"
           :to="item.to"
+          @click="
+            () => {
+              visible = false
+              if (item.to === '/' && route.path === '/') {
+                window.location.reload()
+              }
+            }
+          "
           class="text-gray-800 hover:text-emerald-600 text-base font-medium"
-          @click="visible = false"
         >
           {{ item.label }}
         </RouterLink>
-        <Button label="登入" severity="primary" class="mt-4" @click="visible = false" />
+
+        <RouterLink
+          to="/cart"
+          class="text-gray-800 hover:text-emerald-600 text-base font-medium flex items-center"
+          @click="visible = false"
+        >
+          <i class="pi pi-shopping-cart mr-2"></i>
+          購物車
+          <span
+            v-if="cart.items.length"
+            class="ml-auto bg-red-500 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center"
+          >
+            {{ cart.items.length }}
+          </span>
+        </RouterLink>
+
+        <RouterLink to="/loginsignup" @click="visible = false">
+          <Button label="登入" severity="primary" class="mt-4 w-full"></Button>
+        </RouterLink>
       </div>
     </Drawer>
   </header>
 </template>
-


### PR DESCRIPTION
-變更內容

-導覽列新增購物車ICON、如果點進購物車ICON再跳回首頁能看見購物車顯示幾個項目，在購物車刪除項目可以看到icon數量從2變成1，注意是品項不是商品數量，這是參考露天拍賣的方式。

-刪除首頁、商品詳情頁，點擊LOGO就可以到首頁、點擊商品卡片也能到商品詳情頁，這兩個多餘了。
-後台首頁先留著方便用後續如果移到後面的頁面會刪掉

![image](https://github.com/user-attachments/assets/9ab492b7-0e18-4b95-95be-c843ff7bcf94)
![image](https://github.com/user-attachments/assets/e48e8750-cb55-4bfe-aadf-a120af8a2812)


-驗證方式

嘗試在購物車頁面裡刪除商品。
