### PR TITLE
feat: 完成註冊功能

### DIFF
--- a/src/views/LoginSignup.vue
+++ b/src/views/LoginSignup.vue
@@ -1,5 +1,7 @@
 <script setup>
   import { ref } from 'vue'
+  import axios from 'axios'
+  import { useRouter } from 'vue-router'
   import Button from 'primevue/button'
 
   const isLogin = ref(true)
@@ -7,7 +9,10 @@
   const email = ref('')
   const password = ref('')
   const errorMessage = ref('')
+  const successMessage = ref('')
   const isPasswordVisible = ref(false)
+
+  const router = useRouter()
 
   const togglePasswordVisibility = () => {
     isPasswordVisible.value = !isPasswordVisible.value
@@ -17,8 +22,9 @@
     isLogin.value = !isLogin.value
   }
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     errorMessage.value = ''
+    successMessage.value = ''
 
     if (isLogin.value) {
       if (!email.value || !password.value) {
@@ -29,6 +35,40 @@
       if (!username.value || !email.value || !password.value) {
         errorMessage.value = '請填寫所有欄位'
         return
+      }
+    }
+
+    try {
+      const resp = await axios.post(
+        'http://localhost:3000/api/users/register',
+        {
+          username: username.value,
+          email: email.value,
+          password: password.value,
+        }
+      )
+
+      if (resp.status === 201) {
+        successMessage.value = '註冊成功，正在跳轉到登入頁面...'
+        setTimeout(() => {
+          successMessage.value = ''
+          password.value = ''
+          isLogin.value = true
+        }, 2000)
+      }
+    } catch (error) {
+      // 確保 error.response 物件存在並正確處理錯誤
+      if (error.response) {
+        // 如果有 response 物件，則是後端返回的錯誤
+        if (error.response.status === 409) {
+          errorMessage.value = '此 email 已被註冊'
+        } else {
+          errorMessage.value =
+            error.response.data.error || '註冊失敗，請稍後再試！'
+        }
+      } else {
+        // 網路錯誤等情況
+        errorMessage.value = '無法連接到伺服器，請檢查您的網路連接'
       }
     }
   }
@@ -43,6 +83,10 @@
 
       <div v-if="errorMessage" class="text-red-600 text-center mb-4">
         <p>{{ errorMessage }}</p>
+      </div>
+
+      <div v-if="successMessage" class="text-green-600 text-center mb-4">
+        <p>{{ successMessage }}</p>
       </div>
 
       <form @submit.prevent="onSubmit">

--- a/src/views/LoginSignup.vue
+++ b/src/views/LoginSignup.vue
@@ -1,7 +1,6 @@
 <script setup>
   import { ref } from 'vue'
   import axios from 'axios'
-  import { useRouter } from 'vue-router'
   import Button from 'primevue/button'
 
   const isLogin = ref(true)
@@ -11,8 +10,6 @@
   const errorMessage = ref('')
   const successMessage = ref('')
   const isPasswordVisible = ref(false)
-
-  const router = useRouter()
 
   const togglePasswordVisibility = () => {
     isPasswordVisible.value = !isPasswordVisible.value
@@ -57,9 +54,7 @@
         }, 2000)
       }
     } catch (error) {
-      // 確保 error.response 物件存在並正確處理錯誤
       if (error.response) {
-        // 如果有 response 物件，則是後端返回的錯誤
         if (error.response.status === 409) {
           errorMessage.value = '此 email 已被註冊'
         } else {
@@ -67,7 +62,6 @@
             error.response.data.error || '註冊失敗，請稍後再試！'
         }
       } else {
-        // 網路錯誤等情況
         errorMessage.value = '無法連接到伺服器，請檢查您的網路連接'
       }
     }


### PR DESCRIPTION
### 變更內容

- 註冊功能完成

- 填寫必要欄位後，按下建立帳戶按鈕，會打API建立新帳戶到後端

### 驗證方式
後端：
後端測試時可以先刪除 drizzle 資料夾
npm run generate
npm run migrate(如果失敗 用npx drizzle-kit push)
npm run dev

前端：
npm run dev
點擊nav bar登入按鈕
切換到註冊頁面
輸入必要欄位按下建立帳戶按鈕，註冊成功會跳成功訊息，跳轉至登入畫面
確認資料庫userTable是否有成功註冊

### 相關資源
Issue: [feat:完成註冊功能](https://github.com/wanpai-app/frontend/issues/39)
### 備註
錯誤或失敗訊息先用文字顯示，之後會再做彈出視窗
