### PR TITLE
feat: 加入前端渲染畫面

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,13 @@
 <script setup>
-import Navbar from '@/components/layout/NavBar.vue'
-import Footer from '@/components/layout/Footer.vue'
+  import Navbar from '@/components/layout/NavBar.vue'
+  import Footer from '@/components/layout/Footer.vue'
 </script>
 
 <template>
   <Navbar />
-  
+
   <main class="mt-6 bg-gray-50 min-h-screen">
-  <RouterView />
+    <RouterView />
   </main>
 
   <Footer />

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -8,13 +8,11 @@
   <div
     class="bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition-all relative"
   >
-    
     <img
       :src="product.image"
       alt="商品圖片"
       class="w-full h-64 object-contain bg-white"
     />
-
 
     <div class="p-3">
       <p class="text-sm font-medium line-clamp-2 h-[3em] leading-tight">
@@ -22,7 +20,6 @@
       </p>
       <p class="text-lg font-bold mt-2 text-black">${{ product.price }}</p>
     </div>
-
 
     <button
       class="absolute bottom-2 right-2 w-10 h-10 bg-red-500 hover:bg-red-600 text-white p-2 rounded-lg"

--- a/src/components/ProductCategoryFilter.vue
+++ b/src/components/ProductCategoryFilter.vue
@@ -1,16 +1,16 @@
 <script setup>
-import Button from 'primevue/button'
+  import Button from 'primevue/button'
 
-defineProps({
-  categories: Array,
-  activeCategory: String
-})
+  defineProps({
+    categories: Array,
+    activeCategory: String,
+  })
 
-const emit = defineEmits(['update:category'])
+  const emit = defineEmits(['update:category'])
 
-function setCategory(c) {
-  emit('update:category', c)
-}
+  function setCategory(c) {
+    emit('update:category', c)
+  }
 </script>
 
 <template>

--- a/src/components/ProductDetailPage.vue
+++ b/src/components/ProductDetailPage.vue
@@ -46,7 +46,7 @@
 
     <h1 class="mt-4 text-2xl font-bold">{{ product.name }}</h1>
 
-    <p class="mb-2 text-gray-500">{{ product.description }}</p>
+    <p class="mb-2 text-gray-500" v-html="product.description"></p>
 
     <div class="mb-4 text-xl">
       <span

--- a/src/components/ProductDetailPage.vue
+++ b/src/components/ProductDetailPage.vue
@@ -1,93 +1,112 @@
 <script setup>
-  import { ref, onMounted } from 'vue'
-  import axios from 'axios'
-  import { useRoute } from 'vue-router'
+import { ref, onMounted, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+import axios from 'axios'
 
-  import Button from 'primevue/button'
-  import InputNumber from 'primevue/inputnumber'
-  import Image from 'primevue/image'
+import Button from 'primevue/button'
+import InputNumber from 'primevue/inputnumber'
+import Image from 'primevue/image'
 
-  const route = useRoute()
-  const product = ref({})
-  const quantity = ref(1)
+const route = useRoute()
+const product = ref({})
+const quantity = ref(1)
+const inputRef = ref(null)
 
-  onMounted(async () => {
-    const id = route.params.id
-    const res = await axios.get(`/api/products/${id}`)
-    product.value = res.data
-  })
+onMounted(async () => {
+  const id = route.params.id
+  const res = await axios.get(`/api/products/${id}`)
+  product.value = res.data
 
-  const toggleFavorite = async () => {
-    const productId = product.value?.id
-    if (!productId) return
-
-    const originalState = product.value.isFavorited
-    product.value.isFavorited = !originalState
-
-    try {
-      await axios.post(`/api/products/${productId}/favorite`, {
-        favorited: product.value.isFavorited,
-      })
-      // eslint-disable-next-line no-unused-vars
-    } catch (err) {
-      product.value.isFavorited = originalState
-    }
+  await nextTick()
+  if (
+    !document.activeElement ||
+    document.activeElement === document.body
+  ) {
+    inputRef.value?.$el?.querySelector('input')?.focus()
   }
+})
+
+const toggleFavorite = async () => {
+  const productId = product.value?.id
+  if (!productId) return
+
+  const originalState = product.value.isFavorited
+  product.value.isFavorited = !originalState
+
+  try {
+    await axios.post(`/api/products/${productId}/favorite`, {
+      favorited: product.value.isFavorited,
+    })
+  } catch {
+    product.value.isFavorited = originalState
+  }
+}
 </script>
 
 <template>
-  <div class="max-w-xl p-6 mx-auto">
-    <Image
-      :src="product.image"
-      alt="Product Image"
-      imageClass="mt-4 w-64 h-64 object-cover rounded"
-      preview
-    />
+  <div class="max-w-5xl mx-auto p-6">
+    <div class="flex flex-col md:flex-row gap-8">
 
-    <h1 class="mt-4 text-2xl font-bold">{{ product.name }}</h1>
+      <div class="flex-shrink-0 w-full md:w-1/2 text-center">
+        <Image
+          v-if="product.images?.cover"
+          :src="product.images.cover.imgUrl"
+          alt="Product Cover Image"
+          imageClass="w-64 h-64 object-cover rounded mx-auto"
+          preview
+        />
+        <div class="text-sm text-gray-500 mt-2">1 / 3</div>
+      </div>
 
-    <p class="mb-2 text-gray-500" v-html="product.description"></p>
 
-    <div class="mb-4 text-xl">
-      <span
-        v-if="product.discountPrice"
-        class="mr-2 font-semibold text-red-500"
-      >
-        ${{ product.discountPrice }}
-      </span>
-      <span :class="{ 'line-through text-gray-400': product.discountPrice }">
-        ${{ product.price }}
-      </span>
+      <div class="flex flex-col justify-start w-full md:w-1/2 space-y-4">
+
+        <h1 class="text-2xl font-bold leading-snug">{{ product.name }}</h1>
+
+        <div class="text-xl">
+          <span
+            :class="{ 'line-through text-gray-400': product.discountPrice }"
+          >
+            ${{ product.price }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-3">
+          <label for="quantity" class="text-gray-700">數量</label>
+          <InputNumber
+            v-model="quantity"
+            :ref="inputRef"
+            inputId="quantity"
+            :min="1"
+            showButtons
+            buttonLayout="horizontal"
+            decrementButtonClass="p-button-text"
+            incrementButtonClass="p-button-text"
+            inputClass="text-center"
+          >
+            <template #incrementicon>
+              <i class="pi pi-plus" />
+            </template>
+            <template #decrementicon>
+              <i class="pi pi-minus" />
+            </template>
+          </InputNumber>
+        </div>
+
+        <div class="flex gap-4 mt-2">
+          <Button label="加入購物車" icon="pi pi-shopping-cart" class="flex-1" />
+          <Button
+            :label="product.isFavorited ? '取消收藏' : '收藏'"
+            icon="pi pi-heart"
+            class="flex-1"
+            @click="toggleFavorite"
+          />
+        </div>
+      </div>
     </div>
 
-    <div class="flex items-center gap-2 mb-4 w-30">
-      <label for="quantity" class="text-lg text-gray-700">數量</label>
-      <InputNumber
-        v-model="quantity"
-        inputId="quantity"
-        :min="1"
-        showButtons
-        buttonLayout="horizontal"
-        decrementButtonClass="p-button-text"
-        incrementButtonClass="p-button-text"
-        inputClass="text-center"
-      >
-        <template #incrementicon>
-          <i class="pi pi-plus" />
-        </template>
-        <template #decrementicon>
-          <i class="pi pi-minus" />
-        </template>
-      </InputNumber>
-    </div>
-
-    <div class="flex flex-wrap gap-3">
-      <Button label="加入購物車" icon="pi pi-shopping-cart" />
-      <Button
-        :label="product.isFavorited ? '取消收藏' : '收藏'"
-        icon="pi pi-heart"
-        @click="toggleFavorite"
-      />
+    <div class="mt-6">
+      <p class="text-gray-600" v-html="product.description" />
     </div>
   </div>
 </template>

--- a/src/components/ProductDetailPage.vue
+++ b/src/components/ProductDetailPage.vue
@@ -1,52 +1,48 @@
 <script setup>
-import { ref, onMounted, nextTick } from 'vue'
-import { useRoute } from 'vue-router'
-import axios from 'axios'
+  import { ref, onMounted, nextTick } from 'vue'
+  import { useRoute } from 'vue-router'
+  import axios from 'axios'
 
-import Button from 'primevue/button'
-import InputNumber from 'primevue/inputnumber'
-import Image from 'primevue/image'
+  import Button from 'primevue/button'
+  import InputNumber from 'primevue/inputnumber'
+  import Image from 'primevue/image'
 
-const route = useRoute()
-const product = ref({})
-const quantity = ref(1)
-const inputRef = ref(null)
+  const route = useRoute()
+  const product = ref({})
+  const quantity = ref(1)
+  const inputRef = ref(null)
 
-onMounted(async () => {
-  const id = route.params.id
-  const res = await axios.get(`/api/products/${id}`)
-  product.value = res.data
+  onMounted(async () => {
+    const id = route.params.id
+    const res = await axios.get(`/api/products/${id}`)
+    product.value = res.data
 
-  await nextTick()
-  if (
-    !document.activeElement ||
-    document.activeElement === document.body
-  ) {
-    inputRef.value?.$el?.querySelector('input')?.focus()
+    await nextTick()
+    if (!document.activeElement || document.activeElement === document.body) {
+      inputRef.value?.$el?.querySelector('input')?.focus()
+    }
+  })
+
+  const toggleFavorite = async () => {
+    const productId = product.value?.id
+    if (!productId) return
+
+    const originalState = product.value.isFavorited
+    product.value.isFavorited = !originalState
+
+    try {
+      await axios.post(`/api/products/${productId}/favorite`, {
+        favorited: product.value.isFavorited,
+      })
+    } catch {
+      product.value.isFavorited = originalState
+    }
   }
-})
-
-const toggleFavorite = async () => {
-  const productId = product.value?.id
-  if (!productId) return
-
-  const originalState = product.value.isFavorited
-  product.value.isFavorited = !originalState
-
-  try {
-    await axios.post(`/api/products/${productId}/favorite`, {
-      favorited: product.value.isFavorited,
-    })
-  } catch {
-    product.value.isFavorited = originalState
-  }
-}
 </script>
 
 <template>
   <div class="max-w-5xl mx-auto p-6">
     <div class="flex flex-col md:flex-row gap-8">
-
       <div class="flex-shrink-0 w-full md:w-1/2 text-center">
         <Image
           v-if="product.images?.cover"
@@ -58,9 +54,7 @@ const toggleFavorite = async () => {
         <div class="text-sm text-gray-500 mt-2">1 / 3</div>
       </div>
 
-
       <div class="flex flex-col justify-start w-full md:w-1/2 space-y-4">
-
         <h1 class="text-2xl font-bold leading-snug">{{ product.name }}</h1>
 
         <div class="text-xl">
@@ -94,7 +88,11 @@ const toggleFavorite = async () => {
         </div>
 
         <div class="flex gap-4 mt-2">
-          <Button label="加入購物車" icon="pi pi-shopping-cart" class="flex-1" />
+          <Button
+            label="加入購物車"
+            icon="pi pi-shopping-cart"
+            class="flex-1"
+          />
           <Button
             :label="product.isFavorited ? '取消收藏' : '收藏'"
             icon="pi pi-heart"

--- a/src/components/layout/Footer.vue
+++ b/src/components/layout/Footer.vue
@@ -1,6 +1,4 @@
-<script setup>
-
-</script>
+<script setup></script>
 
 <template>
   <footer class="w-full bg-gray-100 text-center text-sm py-2 shadow mt-10">
@@ -12,4 +10,3 @@
     </div>
   </footer>
 </template>
-

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -37,7 +37,24 @@ export function useProductList() {
     },
   })
 
+<<<<<<< HEAD
   inputKeyword.value = searchKeyword.value
+=======
+  const inputKeyword = ref(route.query.keyword || '')
+  const productSection = ref(null)
+
+  watch(
+    () => route.query.keyword,
+    async (val) => {
+      inputKeyword.value = val || ''
+      await nextTick()
+      productSection.value?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      })
+    }
+  )
+>>>>>>> 4fd57d7 (chore: format files with Prettier)
 
   function submitSearch() {
     const keyword = inputKeyword.value.trim()
@@ -59,10 +76,38 @@ export function useProductList() {
     })
   }
 
+<<<<<<< HEAD
   function resetSearch() {
     inputKeyword.value = ''
     router.push({ path: '/', query: {} })
   }
+=======
+  const products = ref([])
+  const brands = [
+    '鋼彈',
+    '海賊王',
+    '鬼滅之刃',
+    'Fate',
+    'EVA',
+    '初音未來',
+    '咒術迴戰',
+    '七龍珠',
+    'Re:Zero',
+    '火影忍者',
+    '東京復仇者',
+    '刀劍神域',
+  ]
+  const items = [
+    '模型',
+    '公仔',
+    '立牌',
+    '雕像',
+    '抱枕',
+    '徽章',
+    '吊飾',
+    'T-shirt',
+  ]
+>>>>>>> 4fd57d7 (chore: format files with Prettier)
 
   const products = ref([])
 
@@ -94,6 +139,7 @@ export function useProductList() {
 
   const filteredProducts = computed(() => {
     let result = products.value
+<<<<<<< HEAD
 
     const keyword = searchKeyword.value.toLowerCase()
 
@@ -105,13 +151,24 @@ export function useProductList() {
       result = result.filter((p) => p.name.toLowerCase().includes(keyword))
     }
 
+=======
+    if (activeCategory.value !== '全部')
+      result = result.filter((p) => p.category === activeCategory.value)
+    if (keyword.value.trim().length >= 1)
+      result = result.filter((p) =>
+        p.name.toLowerCase().includes(keyword.value.toLowerCase())
+      )
+>>>>>>> 4fd57d7 (chore: format files with Prettier)
     return result
   })
 
   const totalPages = computed(() =>
     Math.max(1, Math.ceil(filteredProducts.value.length / itemsPerPage))
   )
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4fd57d7 (chore: format files with Prettier)
   const paginatedProducts = computed(() => {
     const start = (currentPage.value - 1) * itemsPerPage
     return filteredProducts.value.slice(start, start + itemsPerPage)

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -59,38 +59,10 @@ export function useProductList() {
     })
   }
 
-<<<<<<< HEAD
   function resetSearch() {
     inputKeyword.value = ''
     router.push({ path: '/', query: {} })
   }
-=======
-  const products = ref([])
-  const brands = [
-    '鋼彈',
-    '海賊王',
-    '鬼滅之刃',
-    'Fate',
-    'EVA',
-    '初音未來',
-    '咒術迴戰',
-    '七龍珠',
-    'Re:Zero',
-    '火影忍者',
-    '東京復仇者',
-    '刀劍神域',
-  ]
-  const items = [
-    '模型',
-    '公仔',
-    '立牌',
-    '雕像',
-    '抱枕',
-    '徽章',
-    '吊飾',
-    'T-shirt',
-  ]
->>>>>>> 4fd57d7 (chore: format files with Prettier)
 
   const products = ref([])
 
@@ -122,7 +94,6 @@ export function useProductList() {
 
   const filteredProducts = computed(() => {
     let result = products.value
-<<<<<<< HEAD
 
     const keyword = searchKeyword.value.toLowerCase()
 
@@ -134,24 +105,12 @@ export function useProductList() {
       result = result.filter((p) => p.name.toLowerCase().includes(keyword))
     }
 
-=======
-    if (activeCategory.value !== '全部')
-      result = result.filter((p) => p.category === activeCategory.value)
-    if (keyword.value.trim().length >= 1)
-      result = result.filter((p) =>
-        p.name.toLowerCase().includes(keyword.value.toLowerCase())
-      )
->>>>>>> 4fd57d7 (chore: format files with Prettier)
     return result
   })
 
   const totalPages = computed(() =>
     Math.max(1, Math.ceil(filteredProducts.value.length / itemsPerPage))
   )
-<<<<<<< HEAD
-
-=======
->>>>>>> 4fd57d7 (chore: format files with Prettier)
   const paginatedProducts = computed(() => {
     const start = (currentPage.value - 1) * itemsPerPage
     return filteredProducts.value.slice(start, start + itemsPerPage)

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -37,24 +37,7 @@ export function useProductList() {
     },
   })
 
-<<<<<<< HEAD
   inputKeyword.value = searchKeyword.value
-=======
-  const inputKeyword = ref(route.query.keyword || '')
-  const productSection = ref(null)
-
-  watch(
-    () => route.query.keyword,
-    async (val) => {
-      inputKeyword.value = val || ''
-      await nextTick()
-      productSection.value?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      })
-    }
-  )
->>>>>>> 4fd57d7 (chore: format files with Prettier)
 
   function submitSearch() {
     const keyword = inputKeyword.value.trim()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import ProductDetailPage from '../components/ProductDetailPage.vue'
+import ProductDetailPage from '../views/ProductDetailPage.vue'
 import CartView from '@/views/CartView.vue'
 import HomeView from '@/views/HomeView.vue'
 import LoginSignup from '@/views/LoginSignup.vue'

--- a/src/views/OrderManagement.vue
+++ b/src/views/OrderManagement.vue
@@ -1,13 +1,10 @@
 <script setup>
   import { ref, computed } from 'vue'
   import InputText from 'primevue/inputtext'
-  import Select from 'primevue/select';
+  import Select from 'primevue/select'
   import DataTable from 'primevue/datatable'
   import Column from 'primevue/column'
   import Button from 'primevue/button'
-
-
-
 
   const searchOrderId = ref('')
   const selectedDateRange = ref('')
@@ -106,10 +103,9 @@
   }
 </script>
 
-
 <template>
   <div class="p-8 max-w-screen-xl mx-auto">
-    <div class="mb-6 flex  md:flex-row md:items-end gap-4 justify-end ml-auto">
+    <div class="mb-6 flex md:flex-row md:items-end gap-4 justify-end ml-auto">
       <div class="flex flex-col w-full md:w-[230px]">
         <label for="orderId" class="text-sm mb-1">訂單搜尋</label>
         <InputText
@@ -120,19 +116,19 @@
         />
       </div>
 
-    <div class="flex flex-col w-full md:w-[230px]">
-      <label for="dateRange" class="text-sm mb-1">日期</label>
-      <Select
-        id="dateRange"
-        v-model="selectedDateRange"
-        :options="dateOptions"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="全部時間"
-        class="w-full"
-      />
+      <div class="flex flex-col w-full md:w-[230px]">
+        <label for="dateRange" class="text-sm mb-1">日期</label>
+        <Select
+          id="dateRange"
+          v-model="selectedDateRange"
+          :options="dateOptions"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="全部時間"
+          class="w-full"
+        />
+      </div>
     </div>
-  </div>
 
     <h2 class="text-2xl mb-6">我的訂單</h2>
     <DataTable
@@ -185,4 +181,3 @@
     </DataTable>
   </div>
 </template>
-

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -1,0 +1,110 @@
+<script setup>
+  import { ref, onMounted, nextTick } from 'vue'
+  import { useRoute } from 'vue-router'
+  import axios from 'axios'
+
+  import Button from 'primevue/button'
+  import InputNumber from 'primevue/inputnumber'
+  import Image from 'primevue/image'
+
+  const route = useRoute()
+  const product = ref({})
+  const quantity = ref(1)
+  const inputRef = ref(null)
+
+  onMounted(async () => {
+    const id = route.params.id
+    const res = await axios.get(`/api/products/${id}`)
+    product.value = res.data
+
+    await nextTick()
+    if (!document.activeElement || document.activeElement === document.body) {
+      inputRef.value?.$el?.querySelector('input')?.focus()
+    }
+  })
+
+  const toggleFavorite = async () => {
+    const productId = product.value?.id
+    if (!productId) return
+
+    const originalState = product.value.isFavorited
+    product.value.isFavorited = !originalState
+
+    try {
+      await axios.post(`/api/products/${productId}/favorite`, {
+        favorited: product.value.isFavorited,
+      })
+    } catch {
+      product.value.isFavorited = originalState
+    }
+  }
+</script>
+
+<template>
+  <div class="max-w-5xl mx-auto p-6">
+    <div class="flex flex-col md:flex-row gap-8">
+      <div class="flex-shrink-0 w-full md:w-1/2 text-center">
+        <Image
+          v-if="product.images?.cover"
+          :src="product.images.cover.imgUrl"
+          alt="Product Cover Image"
+          imageClass="w-64 h-64 object-cover rounded mx-auto"
+          preview
+        />
+        <div class="text-sm text-gray-500 mt-2">1 / 3</div>
+      </div>
+
+      <div class="flex flex-col justify-start w-full md:w-1/2 space-y-4">
+        <h1 class="text-2xl font-bold leading-snug">{{ product.name }}</h1>
+
+        <div class="text-xl">
+          <span
+            :class="{ 'line-through text-gray-400': product.discountPrice }"
+          >
+            ${{ product.price }}
+          </span>
+        </div>
+
+        <div class="flex items-center gap-3">
+          <label for="quantity" class="text-gray-700">數量</label>
+          <InputNumber
+            v-model="quantity"
+            :ref="inputRef"
+            inputId="quantity"
+            :min="1"
+            showButtons
+            buttonLayout="horizontal"
+            decrementButtonClass="p-button-text"
+            incrementButtonClass="p-button-text"
+            inputClass="text-center"
+          >
+            <template #incrementicon>
+              <i class="pi pi-plus" />
+            </template>
+            <template #decrementicon>
+              <i class="pi pi-minus" />
+            </template>
+          </InputNumber>
+        </div>
+
+        <div class="flex gap-4 mt-2">
+          <Button
+            label="加入購物車"
+            icon="pi pi-shopping-cart"
+            class="flex-1"
+          />
+          <Button
+            :label="product.isFavorited ? '取消收藏' : '收藏'"
+            icon="pi pi-heart"
+            class="flex-1"
+            @click="toggleFavorite"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <p class="text-gray-600" v-html="product.description" />
+    </div>
+  </div>
+</template>

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,13 +8,22 @@ import { fileURLToPath, URL } from 'node:url'
 export default defineConfig({
   plugins: [
     vue(),
-    svgLoader(), // 新增
+    svgLoader(),
     vueDevTools(),
     tailwindcss(),
   ],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '/api'),
+      },
     },
   },
 })


### PR DESCRIPTION
### 變更內容
- 最後有跑 `npm run format` Peittier，只要看真正有改的檔案：`ProductDetailPage.vue`, `vite.config.js`
- `vite.config.js` 增加 server.proxy 使用網頁，讓前端能打後端 API
- `ProductDetailPage.vue` 加入商品資訊渲染方法
- 新增 `nextTick()` 解決 console 跳出的提醒訊息，若目前沒有元素正在 focus，則 focus 到數量欄位

### 驗證方式
1. 確認資料庫有 dump SQL檔案了，檔案傳在 Line/ DC。
本地資料庫要先有 migrate 過才會有表格 ->`psql -U your_user -d your_db -f products.sql`在終端機輸入這個指令匯入，PG 版本不同或 Windows 要自己去查正確匯入指令 
3. `npm run dev` 開啟本地伺服器，後端分支`feat/image-api`跑`npm run dev`
4. 在主頁點擊任一商品卡 
頁面顯示如下圖：
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/0ab5cebe-be76-41c6-b917-707b9bbf1abd" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/1bb08694-6193-4e50-b52e-31d9469dc45f" />


### 相關資源
- Backend: PR- 46
- Closes: #45 

### 備註
- 點擊進入錨點跟上頁一樣不會變，之後需要修改
- 需要再調整頁面切版
- 後端- `getAllProducts`  get 主頁圖片的方法也有加入了，前端主頁頁面渲染上即可