### PR TITLE
feat: navbar notification & notification page api integration

### DIFF
--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -27,7 +27,6 @@
     authStore.logout()
     router.push('/authform')
   }
-
 </script>
 
 <template>
@@ -67,15 +66,35 @@
             </span>
           </div>
         </RouterLink>
-        <div class="hidden md:block">
-        <RouterLink v-if="!authStore.isLoggedIn" to="/authform">
-          <Button label="登入" severity="primary" size="small" />
+
+        <RouterLink
+          v-if="authStore.isLoggedIn"
+          to="/notifications"
+          class="relative flex items-center justify-center mr-2"
+          title="我的通知"
+        >
+          <Button
+            icon="pi pi-comment"
+            text
+            rounded
+            class="w-10 h-10 flex items-center justify-center text-gray-600 hover:text-emerald-600 hover:bg-gray-100 transition"
+            aria-label="通知"
+          />
         </RouterLink>
-        <Button v-else label="登出" severity="danger" size="small" @click="logout" />
-      </div>
-      </div>
 
-
+        <div class="hidden md:block">
+          <RouterLink v-if="!authStore.isLoggedIn" to="/authform">
+            <Button label="登入" severity="primary" size="small" />
+          </RouterLink>
+          <Button
+            v-else
+            label="登出"
+            severity="danger"
+            size="small"
+            @click="logout"
+          />
+        </div>
+      </div>
 
       <div class="md:hidden">
         <Button icon="pi pi-bars" text @click="visible = true" />
@@ -119,13 +138,38 @@
           </span>
         </RouterLink>
 
+        <RouterLink
+          v-if="authStore.isLoggedIn"
+          to="/notifications"
+          class="relative flex items-center justify-center mr-2"
+          title="我的通知"
+        >
+          <Button
+            icon="pi pi-comment"
+            text
+            rounded
+            class="w-10 h-10 flex items-center justify-center text-gray-600 hover:text-emerald-600 hover:bg-gray-100 transition"
+            aria-label="通知"
+          />
+        </RouterLink>
+
         <RouterLink to="/loginsignup" @click="visible = false">
           <Button label="登入" severity="primary" class="mt-4 w-full" />
         </RouterLink>
-        <RouterLink v-if="!authStore.isLoggedIn" to="/authform" @click="visible = false">
+        <RouterLink
+          v-if="!authStore.isLoggedIn"
+          to="/authform"
+          @click="visible = false"
+        >
           <Button label="登入" severity="primary" class="mt-4 w-full" />
         </RouterLink>
-        <Button v-else label="登出" severity="danger" class="mt-4" @click="logout" />
+        <Button
+          v-else
+          label="登出"
+          severity="danger"
+          class="mt-4"
+          @click="logout"
+        />
       </div>
     </Drawer>
   </header>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -50,8 +50,8 @@ const router = createRouter({
       ],
     },
     {
-      path: '/notification',
-      name: 'notification',
+      path: '/notifications',
+      name: 'notifications',
       component: () => import('../views/NotificationPage.vue'),
     },
     {

--- a/src/views/NotificationPage.vue
+++ b/src/views/NotificationPage.vue
@@ -45,7 +45,7 @@
         read: item.read ?? false,
         expanded: false,
       }))
-    } catch (e) {
+    } catch {
       error.value = '通知載入失敗，請稍後再試'
     } finally {
       loading.value = false

--- a/src/views/NotificationPage.vue
+++ b/src/views/NotificationPage.vue
@@ -1,35 +1,58 @@
 <script setup>
-  import { ref, computed, watch } from 'vue'
+  import { ref, computed, watch, onMounted } from 'vue'
   import Divider from 'primevue/divider'
+  import axios from 'axios'
 
   const categories = ref([
     { label: '訂單訊息', type: 'order' },
     { label: '帳戶訊息', type: 'account' },
-    { label: '優惠相關', type: 'promo' },
   ])
 
   const selectedCategory = ref(null)
+  const notifications = ref([])
+  const loading = ref(false)
+  const error = ref('')
 
-  const notifications = ref([
-    {
-      type: 'order',
-      time: '2024-09-16 10:04',
-      username: '會員名稱',
-      message: '您好，感謝您購買本站商品，商品訂單已成立',
-      orderId: '2024090801004604613',
-      read: false,
-      expanded: false,
-    },
-    {
-      type: 'promo',
-      time: '2024-09-01 08:20',
-      username: '系統訊息',
-      message: '限時優惠 88 折，立即搶購！',
-      orderId: '',
-      read: true,
-      expanded: false,
-    },
-  ])
+  const token = localStorage.getItem('token')
+
+  // type 對應資料庫設計
+  function mapType(type) {
+    if (
+      type === 'order_created' ||
+      type === 'order_shipped' ||
+      type === 'order_delivered'
+    )
+      return 'order'
+    if (type === 'account') return 'account'
+    return 'other'
+  }
+
+  // 取得通知資料
+  async function fetchNotifications() {
+    loading.value = true
+    error.value = ''
+    try {
+      const { data } = await axios.get('/api/notifications', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      notifications.value = data.map((item) => ({
+        ...item,
+        type: mapType(item.type),
+        time: item.createdAt ? new Date(item.createdAt).toLocaleString() : '',
+        username: item.username || '系統訊息',
+        message: item.message,
+        orderId: item.orderId ? String(item.orderId) : '',
+        read: item.read ?? false,
+        expanded: false,
+      }))
+    } catch (e) {
+      error.value = '通知載入失敗，請稍後再試'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(fetchNotifications)
 
   watch(selectedCategory, (newType) => {
     notifications.value.forEach((n) => {
@@ -67,7 +90,6 @@
     <h2 class="text-2xl font-bold mb-6 ml-8">我的通知</h2>
 
     <div class="flex gap-6">
-      <!-- 左側分類 -->
       <aside class="w-40">
         <ul class="list-none p-0 m-0">
           <li
@@ -89,12 +111,18 @@
       </aside>
 
       <section class="flex-1 flex items-center justify-center">
-        <div v-if="!selectedCategory" class="text-center">
+        <div v-if="loading" class="text-center text-gray-500 py-10">
+          載入中...
+        </div>
+        <div v-else-if="error" class="text-center text-red-500 py-10">
+          {{ error }}
+        </div>
+
+        <div v-else-if="!selectedCategory" class="text-center">
           <span
             class="pi pi-inbox text-9xl text-gray-400 mb-6 block mx-auto"
             aria-hidden="true"
           ></span>
-
           <h3 class="text-xl font-semibold mb-2">歡迎來到通知中心</h3>
           <p class="text-gray-500">請從左邊的列表選擇想查看的通知類型</p>
         </div>
@@ -106,7 +134,6 @@
             <span>{{ currentLabel }}</span>
             <span>共 {{ filteredNotifications.length }} 條</span>
           </div>
-
           <Divider class="my-2" />
 
           <div
@@ -138,7 +165,9 @@
                 </strong>
                 {{ item.message }}
               </p>
-              <p class="text-sm text-gray-700">訂單編號：{{ item.orderId }}</p>
+              <p v-if="item.orderId" class="text-sm text-gray-700">
+                訂單編號：{{ item.orderId }}
+              </p>
             </div>
 
             <Divider


### PR DESCRIPTION
新增內容

新增會員登入後，Navbar 顯示通知 icon，點擊可進入通知頁面
通知頁面串接後端 /api/notifications，載入個人通知列表（訂單訊息/帳戶訊息）
資料載入中與錯誤時有提示

測試方式

以會員身份登入後，Navbar 右上角出現通知 icon，可正常點擊進入通知頁
點選不同分類，通知能正確展開
有未讀通知時會顯示紅點，已讀紅點消失
資料載入與異常時有對應提示
<img width="1470" alt="截圖 2025-06-13 上午11 41 06" src="https://github.com/user-attachments/assets/279dbd38-699e-49b8-b7ae-561f753dd2e2" />
<img width="1470" alt="截圖 2025-06-13 上午11 41 14" src="https://github.com/user-attachments/assets/7134b5eb-7d53-4db8-9777-c2418f58d517" />

Close #52 
