### PR TITLE
fix: CommonTable tabs and admin products api

### DIFF
--- a/src/api/product.js
+++ b/src/api/product.js
@@ -1,7 +1,9 @@
 import axios from '@/utils/axiosInstance'
 
 const fetchAllProducts = async (status = 'all') => {
-  const res = await axios.get(`/products?status=${status}`)
+  const res = await axios.get('/admin/products', {
+    params: { status },
+  })
   return res.data
 }
 

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -33,11 +33,13 @@
     scrollHeight: { type: String, default: '500px' },
     selectable: { type: Boolean, default: true },
   })
+
+  const emit = defineEmits(['tab-change'])
 </script>
 
 <template>
   <div class="card">
-    <Tabs v-model:value="activeTab">
+    <Tabs v-model:value="activeTab" @update:value="emit('tab-change', $event)">
       <TabList>
         <Tab v-for="tab in tabs" :key="tab.title" :value="tab.value">
           {{ tab.title }}
@@ -68,7 +70,11 @@
               >
                 <template #body="slotProps">
                   <slot :name="`body-${col.field}`" :data="slotProps.data">
-                    {{ slotProps.data[col.field] }}
+                    {{
+                      col.format
+                        ? col.format(slotProps.data[col.field])
+                        : slotProps.data[col.field]
+                    }}
                   </slot>
                 </template>
               </Column>

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -1,6 +1,6 @@
 import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import axios from '@/utils/axiosInstance'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
 
 export function useProductList() {
   const route = useRoute()
@@ -63,9 +63,7 @@ export function useProductList() {
 
   onMounted(async () => {
     try {
-      const res = await axios.get(
-        `${import.meta.env.VITE_API_BASE_URL}/products`
-      )
+      const res = await axios.get('/products')
       products.value = res.data
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -1,10 +1,21 @@
-// axiosInstance有點像前端的middleware，每次發送請求前可以做一些預處理跟驗證，例如自動附帶token
 import axios from 'axios'
 
 const instance = axios.create({
-  // 設定baseURL: 'http://localhost:3000/api',統一API網址前綴
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   timeout: 10000,
 })
+
+instance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token')
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  }
+)
 
 export default instance

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -4,12 +4,11 @@
   import { fetchAllProducts } from '@/api/product'
   import { onMounted } from 'vue'
   import { useRouter } from 'vue-router'
+  import { useToast } from 'primevue/usetoast'
+  import Toast from 'primevue/toast'
   const router = useRouter()
-  const statusTextMap = {
-    active: '上架中',
-    draft: '草稿',
-    archived: '典藏',
-  }
+  const toast = useToast()
+
   const productTabs = ref([
     { title: '全部', value: 'all' },
     { title: '上架中', value: 'active' },
@@ -19,7 +18,18 @@
   const productColumns = ref([
     { field: 'img', header: '', style: 'width: 25%', sortable: false },
     { field: 'name', header: '商品', style: 'width: 25%', sortable: true },
-    { field: 'status', header: '狀態', style: 'width: 25%', sortable: true },
+    {
+      field: 'status',
+      header: '狀態',
+      style: 'width: 25%',
+      sortable: true,
+      format: (val) =>
+        ({
+          active: '上架中',
+          draft: '草稿',
+          archived: '典藏',
+        })[val] || '未知',
+    },
     {
       field: 'stockOnHand',
       header: '庫存數量',
@@ -27,6 +37,22 @@
       sortable: true,
     },
   ])
+
+  const currentStatus = ref('all')
+  const handleTabChange = async (newStatus) => {
+    currentStatus.value = newStatus
+    try {
+      const res = await fetchAllProducts(newStatus)
+      productValue.value = res
+    } catch (error) {
+      toast.add({
+        severity: 'warn',
+        summary: '商品暫時無法載入',
+        detail: '請稍後再試',
+        life: 3000,
+      })
+    }
+  }
 
   const productValue = ref([])
   onMounted(async () => {
@@ -36,6 +62,7 @@
 </script>
 
 <template>
+  <Toast />
   <div class="flex justify-between items-center mr-8 mb-4">
     <h2 class="text-2xl">商品</h2>
     <div class="card flex justify-center">
@@ -57,13 +84,11 @@
       :tabs="productTabs"
       :columns="productColumns"
       :value="productValue"
+      @tab-change="handleTabChange"
       scrollable
       selectable
       scroll-height="500px"
     >
-      <template #body-status="{ data }">
-        {{ statusTextMap[data.status] || '未知' }}
-      </template>
       <template #body-name="{ data }">
         <a
           class="w-full underline text-primary cursor-pointer"


### PR DESCRIPTION
- 後台商品列表狀態 tab 切換，打 API 顯示相應商品資料
- 新增`src/utils/axiosInstance.js` ，用 axios 打 API 就會自動附帶 token 在 headers，大家寫API的時候記得 import 這個檔案進來，可參考 `src/api/product.js` 寫法

測試方法：

1. 註冊新 user
2. 去資料庫手動將新 user 的 role 設定為`'admin'`
3. 資料庫要有商品資料
4. 後端 npm run dev
5. 前端 npm run dev
6. 登入你自己剛註冊的 admin 帳號
7. 後台商品列表可新增商品，請新增幾筆草稿、典藏商品
8. 回到商品列表後切換 tab，看看新增的商品有沒有出現

close: #66 