### PR TITLE
feat: 通知系統紅點顯示與已讀同步

### DIFF
--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -5,12 +5,16 @@
   import Button from 'primevue/button'
   import { useCartStore } from '@/stores/cart'
   import { useAuthStore } from '@/stores/auth'
+  import { onMounted } from 'vue'
+  import { useNotificationStore } from '@/stores/notifications'
 
   const visible = ref(false)
   const cart = useCartStore()
   const route = useRoute()
   const router = useRouter()
   const authStore = useAuthStore()
+  const notificationStore = useNotificationStore()
+  onMounted(notificationStore.fetch)
 
   const menuItems = [{ label: '後台首頁', to: '/admin' }]
 
@@ -80,6 +84,11 @@
             class="w-10 h-10 flex items-center justify-center text-gray-600 hover:text-emerald-600 hover:bg-gray-100 transition"
             aria-label="通知"
           />
+
+          <span
+            v-if="notificationStore.totalUnread > 0"
+            class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-white z-10"
+          ></span>
         </RouterLink>
 
         <div class="hidden md:block">
@@ -151,6 +160,11 @@
             class="w-10 h-10 flex items-center justify-center text-gray-600 hover:text-emerald-600 hover:bg-gray-100 transition"
             aria-label="通知"
           />
+
+          <span
+            v-if="notificationStore.totalUnread > 0"
+            class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-white z-10"
+          ></span>
         </RouterLink>
 
         <RouterLink to="/loginsignup" @click="visible = false">

--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -1,0 +1,40 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import axios from 'axios'
+
+export const useNotificationStore = defineStore('notifications', () => {
+  const list = ref([])
+
+  const totalUnread = computed(() => list.value.filter((n) => !n.read).length)
+
+  function mapType(type) {
+    if (
+      type === 'order_created' ||
+      type === 'order_shipped' ||
+      type === 'order_delivered'
+    )
+      return 'order'
+    if (type === 'account') return 'account'
+    return 'other'
+  }
+
+  async function fetch() {
+    const token = localStorage.getItem('token')
+    const { data } = await axios.get('/api/notifications', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    list.value = data.map((item) => ({
+      ...item,
+      type: mapType(item.type),
+      time: item.createdAt ? new Date(item.createdAt).toLocaleString() : '',
+      username: item.username || '系統訊息',
+      message: item.message,
+      orderId: item.orderId ? String(item.orderId) : '',
+      read: item.read ?? false,
+      expanded: false,
+    }))
+  }
+
+  return { list, totalUnread, fetch }
+})

--- a/src/views/NotificationPage.vue
+++ b/src/views/NotificationPage.vue
@@ -2,63 +2,36 @@
   import { ref, computed, watch, onMounted } from 'vue'
   import Divider from 'primevue/divider'
   import axios from 'axios'
+  import { useNotificationStore } from '@/stores/notifications'
 
+  const notificationStore = useNotificationStore()
+  const notifications = computed(() => notificationStore.list)
   const categories = ref([
     { label: '訂單訊息', type: 'order' },
     { label: '帳戶訊息', type: 'account' },
   ])
 
   const selectedCategory = ref(null)
-  const notifications = ref([])
   const loading = ref(false)
   const error = ref('')
-
   const token = localStorage.getItem('token')
 
-  // type 對應資料庫設計
-  function mapType(type) {
-    if (
-      type === 'order_created' ||
-      type === 'order_shipped' ||
-      type === 'order_delivered'
-    )
-      return 'order'
-    if (type === 'account') return 'account'
-    return 'other'
-  }
-
-  // 取得通知資料
-  async function fetchNotifications() {
+  onMounted(async () => {
     loading.value = true
     error.value = ''
     try {
-      const { data } = await axios.get('/api/notifications', {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      notifications.value = data.map((item) => ({
-        ...item,
-        type: mapType(item.type),
-        time: item.createdAt ? new Date(item.createdAt).toLocaleString() : '',
-        username: item.username || '系統訊息',
-        message: item.message,
-        orderId: item.orderId ? String(item.orderId) : '',
-        read: item.read ?? false,
-        expanded: false,
-      }))
+      await notificationStore.fetch()
     } catch {
       error.value = '通知載入失敗，請稍後再試'
     } finally {
       loading.value = false
     }
-  }
-
-  onMounted(fetchNotifications)
+  })
 
   watch(selectedCategory, (newType) => {
     notifications.value.forEach((n) => {
       if (n.type === newType) {
         n.expanded = true
-        n.read = true
       }
     })
   })
@@ -73,10 +46,21 @@
       ''
   )
 
-  function toggleExpanded(item) {
+  async function toggleExpanded(item) {
     item.expanded = !item.expanded
     if (!item.read) {
-      item.read = true
+      try {
+        await axios.patch(
+          `/api/notifications/${item.id}/read`,
+          {},
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+        item.read = true
+      } catch {
+        // 忽略錯誤
+      }
     }
   }
 
@@ -154,7 +138,7 @@
               {{ item.time }}
               <span
                 v-if="!item.read"
-                class="pi pi-circle-fill text-xs text-red-600"
+                class="inline-block w-2 h-2 align-middle bg-red-500 rounded-full ml-2"
               ></span>
             </p>
 


### PR DESCRIPTION
### ✨ 功能說明 | Feature Summary
- 新增通知紅點顯示功能（navbar 與分類）
- 點擊通知後，紅點自動消失，並更新後端已讀狀態
- 使用者體驗上，已讀狀態即時同步、畫面一致
---
（先開後端）測試方式 ：

切到我的分支22-feat/create-notification-api
驗證方式：
執行 npm i
執行 npm run migrate
執行 npm run dev

使用 Postman 測試：

註冊會員（POST）
http://localhost:3000/api/users/register
Body：
{
"username": "rose",
"email": "[rose@example.com](mailto:rose@example.com)",
"password": "123"
}
登入會員（POST）
http://localhost:3000/api/users/login
Body：
{
"email": "[rose@example.com](mailto:rose@example.com)",
"password": "123"
}
會拿到 JWT token

建立通知（POST）
http://localhost:3000/api/notifications
Headers：Authorization: Bearer <your_token>
Body：
{
"type": "order_created",
"message": "您有一筆訂單已成立！",
"orderId": 1234
}
查詢通知（GET）
http://localhost:3000/api/notifications
Headers：Authorization: Bearer <your_token>

成功會看到你剛剛建立的通知資料：
[
{
"id": 1,
"userId": 3,
"type": "order_created",
"message": "您有一筆訂單已成立！",
"orderId": 1234,
"read": false,
"createdAt": "2025-06-17T07:50:00.000Z"
}
]

之後到前端登入帳號，會看到有未讀訊息，點navbar 通知icon進入通知頁面，左側分類會出現紅點顯示哪種通知類型有未讀訊息，點進未讀訊息後，所有未讀紅點同步消失，查看Postman 狀態變更"read": true,
<img width="1470" alt="截圖 2025-06-18 下午1 31 47" src="https://github.com/user-attachments/assets/85d66af8-71f4-4ec2-ac9f-471343bbb2fb" />
<img width="1470" alt="截圖 2025-06-18 下午1 31 59" src="https://github.com/user-attachments/assets/88862dc2-5ef6-4b6a-a20d-484665285e39" />
<img width="1470" alt="截圖 2025-06-18 下午1 32 08" src="https://github.com/user-attachments/assets/c0db9ded-c7ff-496c-ac12-fef16edb1d10" />
