### PR TITLE
feat: 後台商品列表新增商品縮圖及分頁

### DIFF
--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -55,6 +55,9 @@
               data-key="id"
               scrollable
               scroll-height="500px"
+              paginator
+              :rows="20"
+              :rowsPerPageOptions="[5, 10, 20, 50]"
             >
               <Column
                 selection-mode="multiple"

--- a/src/views/Admin/AdminHome.vue
+++ b/src/views/Admin/AdminHome.vue
@@ -2,9 +2,6 @@
   import InputText from '@/volt/InputText.vue'
   import Menu from '@/volt/Menu.vue'
   import { ref } from 'vue'
-  // import { useRouter } from 'vue-router'
-
-  // const router = useRouter()
   const search = ref('')
   const items = ref([
     {
@@ -26,7 +23,7 @@
 </script>
 
 <template>
-  <header class="w-full fixed top-0 left-0 right-0 p-4 z-10 bg-amber-950">
+  <header class="w-full fixed top-0 left-0 right-0 p-4 z-20 bg-amber-950">
     <div class="w-2/3 flex justify-between items-center">
       <div>
         <img src="" alt="logo" />

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -6,6 +6,7 @@
   import { useRouter } from 'vue-router'
   import { useToast } from 'primevue/usetoast'
   import Toast from 'primevue/toast'
+  import Image from 'primevue/image'
   const router = useRouter()
   const toast = useToast()
 
@@ -16,7 +17,7 @@
     { title: '典藏', value: 'archived' },
   ])
   const productColumns = ref([
-    { field: 'img', header: '', style: 'width: 25%', sortable: false },
+    { field: 'coverImage', header: '', style: 'width: 25%', sortable: false },
     { field: 'name', header: '商品', style: 'width: 25%', sortable: true },
     {
       field: 'status',
@@ -89,6 +90,15 @@
       selectable
       scroll-height="500px"
     >
+      <template #body-coverImage="{ data }">
+        <Image
+          v-if="data.coverImage"
+          :src="data.coverImage"
+          alt="Product Cover Image"
+          imageClass="w-32 h-32 object-cover rounded mx-auto"
+          loading="lazy"
+        />
+      </template>
       <template #body-name="{ data }">
         <a
           class="w-full underline text-primary cursor-pointer"


### PR DESCRIPTION
- 商品一頁可以看20筆商品，加速載入

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/b6fa0f64-fb5d-4179-9b0f-e2d72f9b5028" />
