### PR TITLE
fix: 修復非管理員用戶可以直接訪問後台管理頁面的問題

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,22 @@
 <script setup>
   import Navbar from '@/components/layout/NavBar.vue'
   import Footer from '@/components/layout/Footer.vue'
+  import { onMounted } from 'vue'
+  import { useToast } from 'primevue/usetoast'
+  import { useAuthStore } from '@/stores/auth'
+  import Toast from 'primevue/toast'
+
+  const toast = useToast()
+  const authStore = useAuthStore()
+
+  onMounted(() => {
+  authStore.setToastHandler(toast)
+  })
 </script>
 
 <template>
   <Navbar />
+  <Toast />
 
   <main class="mt-6 bg-gray-50 min-h-screen">
     <RouterView />

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { useAuthStore } from './stores/auth'
 import App from './App.vue'
 import router from './router'
 import PrimeVue from 'primevue/config'
@@ -21,6 +22,9 @@ app.use(PrimeVue, {
   },
 })
 app.use(ToastService)
+
+const authStore = useAuthStore()
+authStore.initAuth()
 
 router.afterEach(() => {
   document.body.style.overflow = 'auto'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,26 +1,23 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import ProductDetailPage from '../views/ProductDetailPage.vue'
-import CartView from '@/views/CartView.vue'
-import HomeView from '@/views/HomeView.vue'
-import AuthForm from '@/views/AuthForm.vue'
-
+import { useAuthStore } from '@/stores/auth'
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',
       name: 'home',
-      component: HomeView,
+      component: () => import('../views/HomeView.vue'),
     },
     {
       path: '/products/:id',
       name: 'product-detail',
-      component: ProductDetailPage,
+      component:() => import('../views/ProductDetailPage.vue'),
     },
     {
       path: '/admin',
       name: 'admin',
       component: () => import('../views/Admin/AdminHome.vue'),
+      meta: { requiresAuth: true, requiresAdmin: true },
       children: [
         {
           path: 'products',
@@ -48,33 +45,69 @@ const router = createRouter({
       path: '/notifications',
       name: 'notifications',
       component: () => import('../views/NotificationPage.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/productdetailpage',
       name: 'productdetailpage',
-      component: ProductDetailPage,
+      component: () => import('../views/ProductDetailPage.vue'),
     },
     {
       path: '/cart',
       name: 'cart',
-      component: CartView,
+      component: () => import('../views/CartView.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/orders',
       name: 'Orders',
       component: () => import('@/views/OrderManagement.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/authform',
       name: 'authform',
-      component: AuthForm,
+      component: () => import('../views/AuthForm.vue'),
     },
     {
       path: '/orderdetail/:id',
       name: 'OrderDetail',
       component: () => import('@/views/OrderDetail.vue'),
+      meta: { requiresAuth: true },
     },
   ],
+})
+
+router.beforeEach((to, from, next) => {
+  const authStore = useAuthStore()
+
+  if (to.meta.requiresAuth && !authStore.isLoggedIn) {
+    if (authStore.showToast) {
+      authStore.showToast.add({
+        severity: 'warn',
+        summary: '需要登入',
+        detail: '請先登入才能訪問此頁面',
+        life: 3000
+      })
+    }
+    next('/authform')
+    return
+  }
+
+  if (to.meta.requiresAdmin && !authStore.isAdmin) {
+    if (authStore.showToast) {
+      authStore.showToast.add({
+        severity: 'error',
+        summary: '權限不足',
+        detail: '需要管理員權限才能訪問此頁面',
+        life: 3000
+      })
+    }
+    next('/')
+    return
+  }
+
+  next()
 })
 
 export default router

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -4,10 +4,21 @@ export const useAuthStore = defineStore('auth', {
   state: () => ({
     isLoggedIn: false,
     token: null,
-    role: null
+    role: null,
+    showToast: null,
   }),
 
+  getters: {
+    isAdmin: (state) => state.role === 'admin',
+    isUser: (state) => state.role === 'user',
+    userRole: (state) => state.role,
+  },
+
   actions: {
+    setToastHandler(toastFn) {
+      this.showToast = toastFn
+    },
+    
     initAuth() {
       const token = localStorage.getItem('token')
       const role = localStorage.getItem('role')


### PR DESCRIPTION
### 變更內容
新增路由攔截，攔截未授權的訪問
新增 isAdmin、isUser 等 getter 方便權限判斷
非管理員訪問後台會出現toast通知：權限不足
非登入狀態訪問會出現需先登入的通知


