### PR TITLE
feat: complete favorites page UI layout

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -76,6 +76,11 @@ const router = createRouter({
       component: () => import('@/views/OrderDetail.vue'),
     },
     {
+      path: '/favorites',
+      name: 'Favorites',
+      component: () => import('@/views/FavoritePage.vue'),
+    },
+    {
       path: '/:pathMatch(.*)*',
       name: 'NotFound',
       component: NotFound,

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -1,0 +1,192 @@
+<template>
+  <div class="bg-gray-50 min-h-screen py-10 px-4">
+    <Toast />
+    <div class="max-w-6xl mx-auto flex gap-6">
+      <aside class="w-64 bg-white rounded-xl shadow p-6">
+        <div class="mb-6 flex items-center gap-3">
+          <div
+            class="w-10 h-10 bg-primary-500 rounded-full flex items-center justify-center"
+          >
+            <i class="pi pi-user text-white"></i>
+          </div>
+          <span class="font-bold text-xl text-gray-800">我的帳戶</span>
+        </div>
+        <nav class="space-y-2">
+          <RouterLink
+            to="/profile"
+            :class="[
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+              route.path === '/profile'
+                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+            ]"
+          >
+            <i class="pi pi-user"></i>
+            個人資料
+          </RouterLink>
+
+          <RouterLink
+            to="/orders"
+            :class="[
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+              route.path === '/orders'
+                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+            ]"
+          >
+            <i class="pi pi-shopping-cart"></i>
+            訂單中心
+          </RouterLink>
+
+          <RouterLink
+            to="/favorites"
+            :class="[
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+              route.path === '/favorites'
+                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+            ]"
+          >
+            <i class="pi pi-heart"></i>
+            收藏清單
+          </RouterLink>
+        </nav>
+      </aside>
+
+      <div class="flex-1 bg-white rounded-xl shadow p-6">
+        <h2
+          class="text-xl font-semibold mb-4 text-center flex items-center justify-center gap-2"
+        >
+          <i class="pi pi-heart text-gray-400 text-lg"></i>
+          我的收藏
+        </h2>
+
+        <div v-if="favorites.length === 0" class="text-gray-500 text-center">
+          目前沒有收藏商品
+        </div>
+
+        <div v-else>
+          <div
+            class="grid grid-cols-12 px-4 py-2 bg-gray-100 text-sm text-gray-600 font-medium rounded-t-xl"
+          >
+            <div class="col-span-6 text-center">商品資料</div>
+            <div class="col-span-2 text-center">單價</div>
+            <div class="col-span-4 text-left pl-12">數量</div>
+          </div>
+
+          <div
+            v-for="(item, index) in favorites"
+            :key="item.id"
+            :class="[
+              'grid grid-cols-12 gap-4 px-4 py-4 items-center',
+              index !== favorites.length - 1 ? 'border-b border-gray-200' : '',
+            ]"
+          >
+            <div class="col-span-6 flex gap-4 items-start">
+              <img
+                :src="item.image"
+                alt="商品圖片"
+                class="w-24 h-24 object-cover rounded-md"
+              />
+              <div>
+                <div class="text-sm text-gray-500">{{ item.refId }}</div>
+                <div class="text-base font-semibold">{{ item.name }}</div>
+              </div>
+            </div>
+
+            <div class="col-span-2 text-gray-800 font-medium text-center">
+              NT${{ item.price }}
+            </div>
+
+            <div class="col-span-4 flex gap-2 items-center justify-center">
+              <Dropdown
+                v-model="item.quantity"
+                :options="[1, 2, 3, 4, 5]"
+                placeholder="數量"
+                class="w-24"
+                :pt="{
+                  root: { class: 'h-[36px] text-sm' },
+                  input: { class: 'text-sm' },
+                }"
+              />
+              <Button
+                label="加入購物車"
+                size="small"
+                :disabled="!item.quantity"
+                :class="!item.quantity ? 'opacity-50 cursor-not-allowed' : ''"
+                @click="addToCart(item)"
+              />
+              <Button
+                icon="pi pi-trash"
+                severity="secondary"
+                text
+                size="small"
+                @click="removeFavorite(item.id)"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+  import { RouterLink, useRoute } from 'vue-router'
+  import Dropdown from 'primevue/dropdown'
+  import Button from 'primevue/button'
+  import axios from 'axios'
+  import { useToast } from 'primevue/usetoast'
+
+  const toast = useToast()
+  const route = useRoute()
+
+  const favorites = ref([
+    {
+      id: 1,
+      refId: '25032014',
+      name: '小白模型',
+      image: 'https://via.placeholder.com/100x100',
+      price: 320,
+      quantity: null,
+    },
+    {
+      id: 2,
+      refId: '25032015',
+      name: '小白模型2',
+      image: 'https://via.placeholder.com/100x100',
+      price: 320,
+      quantity: null,
+    },
+  ])
+
+  async function addToCart(item) {
+    const token = localStorage.getItem('token')
+    try {
+      await axios.post(
+        '/api/cart',
+        {
+          productId: item.id,
+          quantity: item.quantity,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+    } catch (error) {
+      toast.add({
+        severity: 'error',
+        summary: '加入失敗',
+        detail: `無法加入購物車：${error.message || '請稍後再試'}`,
+        life: 3000,
+      })
+    }
+  }
+
+  function removeFavorite(id) {
+    favorites.value = favorites.value.filter((f) => f.id !== id)
+  }
+</script>


### PR DESCRIPTION
✅ 主要內容

完成收藏清單頁面 UI 切版（使用 PrimeVue + Tailwind CSS）
側邊欄樣式根據路由自動高亮
加入假資料可先行測試畫面
🧪 測試方式

進入http://localhost:5173/favorites頁面
側邊欄點選「收藏清單」高亮正常
加入購物車時若未選數量，按鈕會禁用
📌 備註

尚未串接真實商品資料與會員資訊，之後會再補上
<img width="1470" alt="截圖 2025-06-19 下午3 44 24" src="https://github.com/user-attachments/assets/737ec4bd-5860-47b0-bd30-8f09fa30f016" />
