### PR TITLE
feat: 將各頁面的路徑從打本機改為打到我們部署好的後端

### DIFF
--- a/src/api/createEcpayOrder.js
+++ b/src/api/createEcpayOrder.js
@@ -1,11 +1,8 @@
-import axios from 'axios'
+import axios from '@/utils/axiosInstance'
 
 export async function createEcpayOrder(payload, toast) {
   try {
-    const response = await axios.post(
-      'http://localhost:3000/api/create-order',
-      payload
-    )
+    const response = await axios.post('/create-order', payload)
 
     if (response.data && response.data.includes('<form id="_form_aiochk"')) {
       const div = document.createElement('div')

--- a/src/views/AuthForm.vue
+++ b/src/views/AuthForm.vue
@@ -3,7 +3,7 @@
   import { useRouter } from 'vue-router'
   import { useAuthStore } from '@/stores/auth'
   import { useToast } from 'primevue/usetoast'
-  import axios from 'axios'
+  import axios from '@/utils/axiosInstance'
   import Button from 'primevue/button'
   import Toast from 'primevue/toast'
 
@@ -40,7 +40,7 @@
     }
 
     try {
-      const resp = await axios.post('http://localhost:3000/api/users/login', {
+      const resp = await axios.post('/users/login', {
         email: email.value,
         password: password.value,
       })
@@ -102,7 +102,6 @@
       return
     }
 
-    // 簡單的密碼強度檢查
     if (password.value.length < 6) {
       toast.add({
         severity: 'warn',
@@ -114,14 +113,11 @@
     }
 
     try {
-      const resp = await axios.post(
-        'http://localhost:3000/api/users/register',
-        {
-          username: username.value,
-          email: email.value,
-          password: password.value,
-        }
-      )
+      const resp = await axios.post('/users/register', {
+        username: username.value,
+        email: email.value,
+        password: password.value,
+      })
 
       if (resp.status === 201) {
         toast.add({

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -1,7 +1,7 @@
 <script setup>
   import { ref, onMounted, nextTick } from 'vue'
   import { useRoute } from 'vue-router'
-  import axios from 'axios'
+  import axios from '@/utils/axiosInstance'
   import Image from 'primevue/image'
   import Button from 'primevue/button'
   import InputNumber from 'primevue/inputnumber'
@@ -15,7 +15,7 @@
     window.scrollTo(0, 0)
 
     const id = route.params.id
-    const res = await axios.get(`/api/products/${id}`)
+    const res = await axios.get(`/products/${id}`)
     product.value = res.data
 
     await nextTick()
@@ -32,7 +32,7 @@
     product.value.isFavorited = !originalState
 
     try {
-      await axios.post(`/api/products/${productId}/favorite`, {
+      await axios.post(`/products/${productId}/favorite`, {
         favorited: product.value.isFavorited,
       })
     } catch {

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { ref, onMounted } from 'vue'
-  import axios from 'axios'
+  import axios from '@/utils/axiosInstance' // ✅ 用你的 axios instance
   import InputText from 'primevue/inputtext'
   import { useToast } from 'primevue/usetoast'
   import Toast from 'primevue/toast'
@@ -19,14 +19,7 @@
 
   onMounted(async () => {
     try {
-      const response = await axios.get(
-        'http://localhost:3000/api/users/profile',
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        }
-      )
+      const response = await axios.get('/users/profile') // ✅ 改成相對路徑
       profile.value = response.data
       editProfile.value = { ...profile.value }
     } catch {
@@ -54,6 +47,7 @@
   async function onSave() {
     emailError.value = ''
     phoneError.value = ''
+
     if (!isValidEmail(editProfile.value.email)) {
       emailError.value = 'Email 格式錯誤'
       toast.add({
@@ -64,6 +58,7 @@
       })
       return
     }
+
     if (
       !editProfile.value.username ||
       editProfile.value.username.trim() === ''
@@ -89,16 +84,11 @@
     }
 
     try {
-      await axios.put(
-        'http://localhost:3000/api/users/profile',
-        editProfile.value,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      )
+      await axios.put('/users/profile', editProfile.value, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
 
       profile.value = { ...editProfile.value }
       isEdit.value = false


### PR DESCRIPTION
### 變更內容
將有使用到 import axios from 'axios'的地方都改成 import axios from '@/utils/axiosInstance'
各頁面原本寫死打給3000的改成打到正確部署好後端的路徑

### 修改原因
- 沒有更改的話打不過去唷

### 驗證方式
1. 請先將前端的環境變數改成 VITE_API_BASE_URL=https://wanpai-backend.zeabur.app/api
2. `npm run dev` 開啟本PR分支的伺服器 不需要開啟後端 目前是連接到後端部署的伺服器了
3. 目前商品列表、商品詳情、註冊、登入都已經完成驗證可以打到API


### 備註
-通知訊息還沒有完成，但可以先合併進去測試能不能跑到綠界的結帳畫面