### PR TITLE
feat: 後台新增、編輯商品圖片

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,5 +5,6 @@
       "@/*": ["src/*"]
     }
   },
+  "files": ["src/main.js"],
   "exclude": ["node_modules", "dist"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "tailwindcss": "^4.1.5",
         "tailwindcss-primeui": "^0.6.1",
         "vue": "^3.5.13",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -5088,6 +5089,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5602,6 +5609,18 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "tailwindcss": "^4.1.5",
     "tailwindcss-primeui": "^0.6.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/api/product.js
+++ b/src/api/product.js
@@ -12,13 +12,59 @@ const fetchProductById = async (id) => {
   return res.data
 }
 
-const createProduct = async (data) => {
-  const res = await axios.post('/admin/products', data)
+const createProduct = async ({
+  name,
+  price,
+  coverImageFile,
+  previewImageFiles,
+}) => {
+  const formData = new FormData()
+  formData.append('name', name)
+  formData.append('price', price)
+
+  if (coverImageFile) {
+    formData.append('cover', coverImageFile)
+  }
+
+  if (Array.isArray(previewImageFiles)) {
+    previewImageFiles.forEach((file) => {
+      formData.append('previews', file)
+    })
+  }
+
+  const res = await axios.post('/admin/products', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
+
   return res.data
 }
 
-const updateProduct = async (id, data) => {
-  const res = await axios.put(`/admin/products/${id}`, data)
+const updateProduct = async (
+  id,
+  { name, price, coverImageFile, previewImageFiles }
+) => {
+  const formData = new FormData()
+  formData.append('name', name)
+  formData.append('price', price)
+
+  if (coverImageFile) {
+    formData.append('cover', coverImageFile)
+  }
+
+  if (Array.isArray(previewImageFiles)) {
+    previewImageFiles.forEach((file) => {
+      formData.append('previews', file)
+    })
+  }
+
+  const res = await axios.put(`/admin/products/${id}`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
+
   return res.data
 }
 

--- a/src/api/product.js
+++ b/src/api/product.js
@@ -12,62 +12,25 @@ const fetchProductById = async (id) => {
   return res.data
 }
 
-const createProduct = async ({
-  name,
-  price,
-  coverImageFile,
-  previewImageFiles,
-}) => {
-  const formData = new FormData()
-  formData.append('name', name)
-  formData.append('price', price)
-
-  if (coverImageFile) {
-    formData.append('cover', coverImageFile)
-  }
-
-  if (Array.isArray(previewImageFiles)) {
-    previewImageFiles.forEach((file) => {
-      formData.append('previews', file)
-    })
-  }
-
-  const res = await axios.post('/admin/products', formData, {
+const createProduct = async (productData) => {
+  const res = await axios.post('/admin/products', productData, {
     headers: {
-      'Content-Type': 'multipart/form-data',
+      'Content-Type': 'application/json',
     },
   })
 
   return res.data
 }
 
-const updateProduct = async (
-  id,
-  { name, price, coverImageFile, previewImageFiles }
-) => {
-  const formData = new FormData()
-  formData.append('name', name)
-  formData.append('price', price)
-
-  if (coverImageFile) {
-    formData.append('cover', coverImageFile)
-  }
-
-  if (Array.isArray(previewImageFiles)) {
-    previewImageFiles.forEach((file) => {
-      formData.append('previews', file)
-    })
-  }
-
-  const res = await axios.put(`/admin/products/${id}`, formData, {
+const updateProduct = async (id, productData) => {
+  const res = await axios.put(`/admin/products/${id}`, productData, {
     headers: {
-      'Content-Type': 'multipart/form-data',
+      'Content-Type': 'application/json',
     },
   })
 
   return res.data
 }
-
 
 const fetchFilterData = async () => {
   const res = await axios.get('/tags/filter')

--- a/src/api/productImage.js
+++ b/src/api/productImage.js
@@ -1,0 +1,10 @@
+import api from '@/utils/axiosInstance'
+
+export const fetchProductImages = (productId) =>
+  api.get(`/admin/products/${productId}/images`)
+
+export const uploadProductImage = (productId, formData) =>
+  api.post(`/admin/products/${productId}/images`, formData)
+
+export const deleteProductImage = (productId, imageId) =>
+  api.delete(`/admin/products/${productId}/images/${imageId}`)

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { definePreset } from '@primeuix/themes'
 import Aura from '@primeuix/themes/aura'
 import 'primeicons/primeicons.css'
 import ToastService from 'primevue/toastservice'
+import Toast from 'primevue/toast'
 
 const app = createApp(App)
 const MyPreset = definePreset(Aura, {
@@ -54,6 +55,7 @@ app.use(PrimeVue, {
   },
 })
 app.use(ToastService)
+app.component('Toast', Toast)
 
 const authStore = useAuthStore()
 authStore.initAuth()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,7 +11,7 @@ const router = createRouter({
     },
     {
       path: '/products/:id',
-      name: 'product-detail',
+      name: 'productDetail',
       component: () => import('../views/ProductDetailPage.vue'),
     },
     {
@@ -26,7 +26,12 @@ const router = createRouter({
           component: () => import('../views/Admin/AdminProducts.vue'),
         },
         {
-          path: 'products/edit/:id?',
+          path: 'products/create',
+          name: 'createProduct',
+          component: () => import('../views/Admin/EditProduct.vue'),
+        },
+        {
+          path: 'products/edit/:id',
           name: 'editProduct',
           component: () => import('../views/Admin/EditProduct.vue'),
         },
@@ -49,11 +54,6 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
-      path: '/productdetailpage',
-      name: 'productdetailpage',
-      component: () => import('../views/ProductDetailPage.vue'),
-    },
-    {
       path: '/cart',
       name: 'cart',
       component: () => import('../views/CartView.vue'),
@@ -72,7 +72,7 @@ const router = createRouter({
     },
     {
       path: '/orderdetail/:id',
-      name: 'OrderDetail',
+      name: 'orderDetail',
       component: () => import('@/views/OrderDetail.vue'),
       meta: { requiresAuth: true },
     },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,8 +33,9 @@ const router = createRouter({
         {
           path: 'products/edit/:id',
           name: 'editProduct',
-          component: () => import('../views/Admin/EditProduct.vue'),
+          component: () => import('@/views/Admin/EditProduct.vue'),
         },
+
         {
           path: 'orders',
           name: 'orders',

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { useAuthStore } from '@/stores/auth'
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import { useAuthStore } from '@/stores/auth'
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -39,21 +39,13 @@
     },
   ])
 
-  const currentStatus = ref('all')
-  const handleTabChange = async (newStatus) => {
-    currentStatus.value = newStatus
-    try {
-      const res = await fetchAllProducts(newStatus)
-      productValue.value = res
-    } catch (error) {
-      toast.add({
-        severity: 'warn',
-        summary: '商品暫時無法載入',
-        detail: '請稍後再試',
-        life: 3000,
-      })
-    }
-  }
+const goCreateProduct = () => {
+  router.push({ name: 'createProduct' })
+}
+
+const goEditProduct = (id) => {
+  router.push({ name: 'editProduct', params: { id } })
+}
 
   const productValue = ref([])
   onMounted(async () => {
@@ -69,12 +61,7 @@
     <div class="card flex justify-center">
       <button
         class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
-        @click="
-          router.push({
-            path: '/admin/products/edit',
-            query: { mode: 'create' },
-          })
-        "
+        @click="router.push({ name: 'createProduct' })"
       >
         新增商品
       </button>
@@ -102,12 +89,7 @@
       <template #body-name="{ data }">
         <a
           class="w-full underline text-primary cursor-pointer"
-          @click="
-            router.push({
-              path: `/admin/products/edit/${data.id}`,
-              query: { mode: 'edit' },
-            })
-          "
+          @click="router.push({ name: 'editProduct', params: { id: data.id } })"
         >
           {{ data.name }}
         </a>

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -4,11 +4,9 @@
   import { fetchAllProducts } from '@/api/product'
   import { onMounted } from 'vue'
   import { useRouter } from 'vue-router'
-  import { useToast } from 'primevue/usetoast'
   import Toast from 'primevue/toast'
   import Image from 'primevue/image'
   const router = useRouter()
-  const toast = useToast()
 
   const productTabs = ref([
     { title: '全部', value: 'all' },
@@ -39,15 +37,16 @@
     },
   ])
 
-const goCreateProduct = () => {
-  router.push({ name: 'createProduct' })
-}
-
-const goEditProduct = (id) => {
-  router.push({ name: 'editProduct', params: { id } })
-}
-
   const productValue = ref([])
+
+  const goCreateProduct = () => {
+    router.push({ name: 'createProduct' })
+  }
+
+  const goEditProduct = (id) => {
+    router.push({ name: 'editProduct', params: { id } })
+  }
+
   onMounted(async () => {
     const res = await fetchAllProducts()
     productValue.value = res
@@ -61,7 +60,7 @@ const goEditProduct = (id) => {
     <div class="card flex justify-center">
       <button
         class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
-        @click="router.push({ name: 'createProduct' })"
+        @click="goCreateProduct"
       >
         新增商品
       </button>
@@ -89,7 +88,7 @@ const goEditProduct = (id) => {
       <template #body-name="{ data }">
         <a
           class="w-full underline text-primary cursor-pointer"
-          @click="router.push({ name: 'editProduct', params: { id: data.id } })"
+          @click="goEditProduct(data.id)"
         >
           {{ data.name }}
         </a>

--- a/src/views/Admin/EditProduct.vue
+++ b/src/views/Admin/EditProduct.vue
@@ -1,7 +1,7 @@
 <script setup>
-  import { useRoute } from 'vue-router'
-  import { ref, onMounted } from 'vue'
-  import UploadFile from '@/components/UploadFile.vue'
+  import { useRoute, useRouter } from 'vue-router'
+  import { ref, onMounted, computed } from 'vue'
+  import EditProductImage from '@/views/Admin/EditProductImage.vue'
   import AutoComplete from 'primevue/autocomplete'
   import Select from 'primevue/select'
   import { createProduct, fetchProductById, updateProduct } from '@/api/product'
@@ -10,8 +10,11 @@
   import { useToast } from 'primevue/usetoast'
   import Toast from 'primevue/toast'
   import Checkbox from 'primevue/checkbox'
+
+  const imageUploaderRef = ref(null)
   const showStockEdit = ref(false)
   const toast = useToast()
+  const tagValue = ref([])
 
   const toolbarOptions = [
     ['bold', 'italic', 'underline'],
@@ -22,10 +25,10 @@
   ]
 
   const route = useRoute()
-  const mode = route.query.mode || 'edit'
-  const productId = route.params.id || null
+  const router = useRouter()
 
-  const isCreateMode = mode === 'create'
+  const isCreateMode = computed(() => route.name === 'createProduct')
+  const productId = computed(() => Number(route.params.id) || null)
 
   const statusOptions = ref([
     { name: '草稿', value: 'draft' },
@@ -58,79 +61,59 @@
   const items = ref([])
   // 商品標籤選擇 WIP
   const search = (event) => {
-    items.value = [...Array(10).keys()].map((item) => event.query + '-' + item)
+    items.value = [...Array(10).keys()].map((i) => ({
+      name: `${event.query}-${i}`,
+      code: `TAG-${i}`, // 或者是從 API 來的 id
+    }))
   }
 
   const submit = async () => {
-    if (!form.value.name) {
+    if (!isCreateMode.value && !imageUploaderRef.value.validateBeforeSubmit()) {
+      return
+    }
+
+    if (!form.value.name || !form.value.sku || !form.value.description) {
       toast.add({
         severity: 'warn',
-        summary: '請輸入商品名稱',
+        summary: '欄位未填寫完整',
+        detail: '請填寫商品名稱、貨號與描述',
         life: 3000,
       })
       return
     }
-    if (!form.value.sku) {
-      toast.add({
-        severity: 'warn',
-        summary: '請輸入商品貨號',
-        life: 3000,
-      })
-      return
-    }
-    if (!form.value.description) {
-      toast.add({
-        severity: 'warn',
-        summary: '請輸入商品描述',
-        life: 3000,
-      })
-      return
-    }
-    const productId = route.params.id
-    if (isCreateMode) {
-      try {
-        await createProduct({ ...form.value })
+
+    try {
+      if (isCreateMode.value) {
+        const created = await createProduct(form.value)
         toast.add({
           severity: 'success',
           summary: '成功！',
-          detail: '已成功新增商品',
+          detail: '商品已建立，請上傳圖片',
           life: 3000,
         })
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err)
-        toast.add({
-          severity: 'warn',
-          summary: '哦喔！',
-          detail: '暫時無法新增商品，請稍後再試',
-          life: 3000,
-        })
-      }
-    } else {
-      try {
-        await updateProduct(productId, { ...form.value })
+        router.push({ name: 'editProduct', params: { id: created.id } })
+      } else {
+        await updateProduct(productId.value, form.value)
         toast.add({
           severity: 'success',
           summary: '成功！',
-          detail: '已成功更新商品',
-          life: 3000,
-        })
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err)
-        toast.add({
-          severity: 'warn',
-          summary: '哦喔！',
-          detail: '暫時無法更新商品，請稍後再試',
+          detail: '商品已更新',
           life: 3000,
         })
       }
+    } catch (err) {
+      toast.add({
+        severity: 'warn',
+        summary: '哦喔！',
+        detail: '暫時無法更新商品，請稍後再試',
+        life: 3000,
+      })
     }
   }
 
   onMounted(async () => {
-    if (!isCreateMode && productId) {
-      const res = await fetchProductById(productId)
+    if (!isCreateMode.value && productId.value) {
+      const res = await fetchProductById(productId.value)
       form.value = {
         name: res.name,
         sku: res.sku,
@@ -145,18 +128,63 @@
 
 <template>
   <Toast />
-  <div class="flex justify-center items-start min-h-screen bg-gray-100 py-10">
-    <div class="w-full max-w-3xl bg-white rounded-2xl shadow-xl px-10 py-8">
-      <h2
-        class="text-3xl font-bold mb-6 pb-2 border-b border-gray-200 text-primary"
-      >
-        {{ isCreateMode ? '新增商品' : '編輯商品' }}
-      </h2>
-      <div class="flex flex-col gap-6 mt-2">
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="title">
-            商品名稱
-          </label>
+  <div class="mr-6">
+    <h2 class="text-2xl">
+      {{ isCreateMode ? '新增商品' : '編輯商品' }}
+    </h2>
+    <div class="flex flex-col gap-4 mt-4">
+      <div>
+        <label class="font-bold mb-2 block" for="title">商品名稱</label>
+        <input
+          v-model="form.name"
+          type="text"
+          id="title"
+          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full px-3 py-2 transition-colors duration-200"
+        />
+      </div>
+
+      <div>
+        <label class="font-bold mb-2 block" for="sku">商品貨號</label>
+        <input
+          v-model="form.sku"
+          type="text"
+          id="sku"
+          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full px-3 py-2 transition-colors duration-200"
+        />
+      </div>
+      <div>
+        <label class="font-bold mb-2 block" for="description">商品描述</label>
+        <QuillEditor
+          v-model:content="form.description"
+          content-type="html"
+          :toolbar="toolbarOptions"
+          theme="snow"
+          style="height: 300px"
+        />
+      </div>
+
+      <div>
+        <label class="font-bold mb-2 block" for="image">商品圖片</label>
+        <EditProductImage
+          v-if="!isCreateMode"
+          :productId="productId"
+          ref="imageUploaderRef"
+        />
+      </div>
+      <div>
+        <label class="font-bold mb-2 block" for="price">商品價格</label>
+        <input
+          v-model="form.price"
+          type="number"
+          id="price"
+          min="0"
+          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full md:w-56 px-3 py-2 transition-colors duration-200"
+        />
+      </div>
+
+      <div>
+        <label class="font-bold mb-2 block" for="stock">目前庫存數</label>
+        <div class="flex gap-4 items-end">
           <input
             v-model="form.name"
             type="text"

--- a/src/views/Admin/EditProduct.vue
+++ b/src/views/Admin/EditProduct.vue
@@ -15,6 +15,7 @@
   const showStockEdit = ref(false)
   const toast = useToast()
   const tagValue = ref([])
+  const pendingImages = ref([])
 
   const toolbarOptions = [
     ['bold', 'italic', 'underline'],
@@ -68,10 +69,6 @@
   }
 
   const submit = async () => {
-    if (!isCreateMode.value && !imageUploaderRef.value.validateBeforeSubmit()) {
-      return
-    }
-
     if (!form.value.name || !form.value.sku || !form.value.description) {
       toast.add({
         severity: 'warn',
@@ -85,12 +82,17 @@
     try {
       if (isCreateMode.value) {
         const created = await createProduct(form.value)
+
+        productId.value = created.id
+        await imageUploaderRef.value.uploadPending(created.id)
+
         toast.add({
           severity: 'success',
           summary: '成功！',
-          detail: '商品已建立，請上傳圖片',
+          detail: '商品已建立並完成圖片上傳',
           life: 3000,
         })
+
         router.push({ name: 'editProduct', params: { id: created.id } })
       } else {
         await updateProduct(productId.value, form.value)
@@ -166,8 +168,9 @@
       <div>
         <label class="font-bold mb-2 block" for="image">商品圖片</label>
         <EditProductImage
-          v-if="!isCreateMode"
           :productId="productId"
+          :pending-images="pendingImages"
+          :enabled="!!productId"
           ref="imageUploaderRef"
         />
       </div>

--- a/src/views/Admin/EditProduct.vue
+++ b/src/views/Admin/EditProduct.vue
@@ -1,6 +1,6 @@
 <script setup>
   import { useRoute, useRouter } from 'vue-router'
-  import { ref, onMounted, computed } from 'vue'
+  import { ref, onMounted, computed, reactive, watch } from 'vue'
   import EditProductImage from '@/views/Admin/EditProductImage.vue'
   import AutoComplete from 'primevue/autocomplete'
   import Select from 'primevue/select'
@@ -10,12 +10,17 @@
   import { useToast } from 'primevue/usetoast'
   import Toast from 'primevue/toast'
   import Checkbox from 'primevue/checkbox'
+  import Button from 'primevue/button'
+  import ProgressSpinner from 'primevue/progressspinner'
 
   const imageUploaderRef = ref(null)
   const showStockEdit = ref(false)
   const toast = useToast()
   const tagValue = ref([])
   const pendingImages = ref([])
+  const isLoading = ref(false)
+  const isSaving = ref(false)
+  const isSearchingTags = ref(false)
 
   const toolbarOptions = [
     ['bold', 'italic', 'underline'],
@@ -29,7 +34,7 @@
   const router = useRouter()
 
   const isCreateMode = computed(() => route.name === 'createProduct')
-  const productId = computed(() => Number(route.params.id) || null)
+  const productId = ref(Number(route.params.id) || null)
 
   const statusOptions = ref([
     { name: '草稿', value: 'draft' },
@@ -46,6 +51,15 @@
     status: 'draft',
   })
 
+  const formErrors = reactive({
+    name: '',
+    sku: '',
+    description: '',
+    price: '',
+    stockOnHand: '',
+    stockEditReason: '',
+  })
+
   const stockEditReasonTypes = ref([
     { title: '初始建檔', code: 'initial' },
     { title: '進貨', code: 'stock_in' },
@@ -60,281 +74,698 @@
     { name: '品牌', code: 'brand' },
   ])
   const items = ref([])
-  // 商品標籤選擇 WIP
-  const search = (event) => {
-    items.value = [...Array(10).keys()].map((i) => ({
-      name: `${event.query}-${i}`,
-      code: `TAG-${i}`, // 或者是從 API 來的 id
-    }))
+  const search = async (event) => {
+    if (!event.query || event.query.length < 2) {
+      items.value = []
+      return
+    }
+
+    isSearchingTags.value = true
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      items.value = [...Array(10).keys()]
+        .map((i) => ({
+          name: `${event.query}-${i}`,
+          code: `TAG-${event.query}-${i}`,
+          type: selectedType.value?.code || 'general',
+        }))
+        .filter((item) => !tagValue.value.some((tag) => tag.code === item.code))
+    } catch {
+      items.value = []
+      toast.add({
+        severity: 'warn',
+        summary: '搜尋失敗',
+        detail: '無法搜尋標籤，請稍後再試',
+        life: 3000,
+      })
+    } finally {
+      isSearchingTags.value = false
+    }
+  }
+
+  const removeTag = (tagToRemove) => {
+    tagValue.value = tagValue.value.filter(
+      (tag) => tag.code !== tagToRemove.code
+    )
+  }
+
+  const clearAllTags = () => {
+    tagValue.value = []
+  }
+
+  const validateForm = () => {
+    let isValid = true
+
+    Object.keys(formErrors).forEach((key) => {
+      formErrors[key] = ''
+    })
+
+    if (!form.value.name.trim()) {
+      formErrors.name = '請填寫商品名稱'
+      isValid = false
+    } else if (form.value.name.length < 2) {
+      formErrors.name = '商品名稱至少需要2個字元'
+      isValid = false
+    } else if (form.value.name.length > 100) {
+      formErrors.name = '商品名稱不可超過100個字元'
+      isValid = false
+    }
+
+    if (!form.value.sku.trim()) {
+      formErrors.sku = '請填寫商品貨號'
+      isValid = false
+    } else if (!/^[A-Z0-9\-_]+$/i.test(form.value.sku)) {
+      formErrors.sku = '貨號只能包含英文字母、數字、連字號和底線'
+      isValid = false
+    } else if (form.value.sku.length > 50) {
+      formErrors.sku = '貨號不可超過50個字元'
+      isValid = false
+    }
+
+    if (
+      !form.value.description ||
+      form.value.description.trim() === '' ||
+      form.value.description === '<p></p>'
+    ) {
+      formErrors.description = '請填寫商品描述'
+      isValid = false
+    }
+
+    if (form.value.price < 0) {
+      formErrors.price = '價格不能為負數'
+      isValid = false
+    } else if (form.value.price > 999999) {
+      formErrors.price = '價格不可超過999,999'
+      isValid = false
+    }
+
+    if (form.value.stockOnHand < 0) {
+      formErrors.stockOnHand = '庫存數量不能為負數'
+      isValid = false
+    }
+
+    if (showStockEdit.value && !form.value.stockEditReason) {
+      formErrors.stockEditReason = '修改庫存時請選擇修改原因'
+      isValid = false
+    }
+
+    return isValid
   }
 
   const submit = async () => {
-    if (!form.value.name || !form.value.sku || !form.value.description) {
+    if (!validateForm()) {
       toast.add({
         severity: 'warn',
-        summary: '欄位未填寫完整',
-        detail: '請填寫商品名稱、貨號與描述',
+        summary: '表單驗證失敗',
+        detail: '請檢查並修正表單中的錯誤',
         life: 3000,
       })
       return
     }
 
+    isSaving.value = true
     try {
       if (isCreateMode.value) {
-        const created = await createProduct(form.value)
+        const createData = {
+          name: form.value.name,
+          sku: form.value.sku,
+          description: form.value.description,
+          price: Number(form.value.price),
+          stockOnHand: Number(form.value.stockOnHand),
+          status: form.value.status,
+        }
 
+        if (showStockEdit.value && form.value.stockEditReason) {
+          createData.stockEditReason = form.value.stockEditReason
+        }
+
+        const tempCreateData = { ...createData, status: 'draft' }
+        const created = await createProduct(tempCreateData)
         productId.value = created.id
-        await imageUploaderRef.value.uploadPending(created.id)
+
+        if (imageUploaderRef.value) {
+          await imageUploaderRef.value.uploadPending(created.id)
+        }
+
+        await updateProduct(created.id, createData)
 
         toast.add({
           severity: 'success',
-          summary: '成功！',
-          detail: '商品已建立並完成圖片上傳',
+          summary: '建立成功',
+          detail: '商品已成功建立',
           life: 3000,
         })
 
         router.push({ name: 'editProduct', params: { id: created.id } })
       } else {
-        await updateProduct(productId.value, form.value)
+        const updateData = {
+          name: form.value.name,
+          sku: form.value.sku,
+          description: form.value.description,
+          price: Number(form.value.price),
+          stockOnHand: Number(form.value.stockOnHand),
+          status: form.value.status,
+        }
+
+        if (showStockEdit.value && form.value.stockEditReason) {
+          updateData.stockEditReason = form.value.stockEditReason
+        }
+
+        await updateProduct(productId.value, updateData)
         toast.add({
           severity: 'success',
-          summary: '成功！',
-          detail: '商品已更新',
+          summary: '更新成功',
+          detail: '商品資訊已更新',
           life: 3000,
         })
       }
     } catch (err) {
+      let errorMessage = '操作失敗，請稍後再試'
+
+      if (err.response?.status === 400) {
+        const backendMessage =
+          err.response?.data?.message || err.response?.data?.error
+        if (backendMessage) {
+          errorMessage = `資料驗證錯誤：${backendMessage}`
+        } else {
+          errorMessage = '資料格式錯誤，請檢查表單內容'
+        }
+      } else if (err.response?.status === 409) {
+        errorMessage = '貨號已存在，請使用其他貨號'
+      } else if (err.response?.status === 403) {
+        errorMessage = '權限不足，無法執行此操作'
+      } else if (err.response?.status >= 500) {
+        errorMessage = '伺服器錯誤，請稍後再試'
+      }
+
       toast.add({
-        severity: 'warn',
-        summary: '哦喔！',
-        detail: '暫時無法更新商品，請稍後再試',
-        life: 3000,
+        severity: 'error',
+        summary: '操作失敗',
+        detail: errorMessage,
+        life: 5000,
       })
+    } finally {
+      isSaving.value = false
     }
   }
 
   onMounted(async () => {
     if (!isCreateMode.value && productId.value) {
-      const res = await fetchProductById(productId.value)
-      form.value = {
-        name: res.name,
-        sku: res.sku,
-        description: res.description,
-        price: res.price,
-        stockOnHand: res.stockOnHand,
-        status: res.status,
+      isLoading.value = true
+      try {
+        const res = await fetchProductById(productId.value)
+        form.value = {
+          name: res.name || '',
+          sku: res.sku || '',
+          description: res.description || '',
+          price: Number(res.price) || 0,
+          stockOnHand: Number(res.stockOnHand) || 0,
+          status: res.status || 'draft',
+          stockEditReason: '',
+        }
+      } catch {
+        toast.add({
+          severity: 'error',
+          summary: '載入失敗',
+          detail: '無法載入商品資料，請重新整理頁面',
+          life: 5000,
+        })
+        router.push({ name: 'productList' })
+      } finally {
+        isLoading.value = false
       }
+    }
+  })
+
+  watch(
+    () => route.params.id,
+    (newId) => {
+      productId.value = Number(newId) || null
+    }
+  )
+
+  watch(showStockEdit, (newVal) => {
+    if (!newVal) {
+      form.value.stockEditReason = ''
+      formErrors.stockEditReason = ''
     }
   })
 </script>
 
 <template>
   <Toast />
-  <div class="mr-6">
-    <h2 class="text-2xl">
-      {{ isCreateMode ? '新增商品' : '編輯商品' }}
-    </h2>
-    <div class="flex flex-col gap-4 mt-4">
-      <div>
-        <label class="font-bold mb-2 block" for="title">商品名稱</label>
-        <input
-          v-model="form.name"
-          type="text"
-          id="title"
-          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full px-3 py-2 transition-colors duration-200"
-        />
-      </div>
+  <div class="max-w-6xl mx-auto p-6 bg-white min-h-screen">
+    <div
+      v-if="isLoading"
+      class="flex flex-col justify-center items-center h-96"
+    >
+      <ProgressSpinner style="width: 60px; height: 60px" strokeWidth="6" />
+      <span class="mt-4 text-lg text-gray-600 font-medium">
+        載入商品資料中...
+      </span>
+    </div>
 
-      <div>
-        <label class="font-bold mb-2 block" for="sku">商品貨號</label>
-        <input
-          v-model="form.sku"
-          type="text"
-          id="sku"
-          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full px-3 py-2 transition-colors duration-200"
-        />
-      </div>
-      <div>
-        <label class="font-bold mb-2 block" for="description">商品描述</label>
-        <QuillEditor
-          v-model:content="form.description"
-          content-type="html"
-          :toolbar="toolbarOptions"
-          theme="snow"
-          style="height: 300px"
-        />
-      </div>
-
-      <div>
-        <label class="font-bold mb-2 block" for="image">商品圖片</label>
-        <EditProductImage
-          :productId="productId"
-          :pending-images="pendingImages"
-          :enabled="!!productId"
-          ref="imageUploaderRef"
-        />
-      </div>
-      <div>
-        <label class="font-bold mb-2 block" for="price">商品價格</label>
-        <input
-          v-model="form.price"
-          type="number"
-          id="price"
-          min="0"
-          class="bg-surface-0 rounded-md border-surface-300 border focus:outline-none focus:ring-0 enabled:focus:border-primary w-full md:w-56 px-3 py-2 transition-colors duration-200"
-        />
-      </div>
-
-      <div>
-        <label class="font-bold mb-2 block" for="stock">目前庫存數</label>
-        <div class="flex gap-4 items-end">
-          <input
-            v-model="form.name"
-            type="text"
-            id="title"
-            class="bg-gray-50 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary w-full px-4 py-2 text-lg transition"
-          />
+    <div v-else class="space-y-8">
+      <div class="border-b border-gray-200 pb-6">
+        <div class="flex items-center justify-between">
+          <div>
+            <h1 class="text-3xl font-bold text-gray-900">
+              {{ isCreateMode ? '新增商品' : '編輯商品' }}
+            </h1>
+            <p class="mt-2 text-gray-600">
+              {{ isCreateMode ? '建立新的商品記錄' : '更新商品資訊與設定' }}
+            </p>
+          </div>
+          <div class="flex items-center space-x-3">
+            <Button
+              @click="router.go(-1)"
+              :disabled="isSaving"
+              severity="secondary"
+              outlined
+              class="px-5 py-2.5 font-medium hover:shadow-lg transition-all duration-200 border-2 hover:border-blue-400"
+              icon="pi pi-arrow-left"
+            >
+              返回
+            </Button>
+          </div>
         </div>
+      </div>
 
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="sku">
-            商品貨號
-          </label>
-          <input
-            v-model="form.sku"
-            type="text"
-            id="sku"
-            class="bg-gray-50 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary w-full px-4 py-2 text-lg transition"
-          />
-        </div>
-        <div>
-          <label
-            class="font-semibold mb-2 block text-gray-700"
-            for="description"
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div class="lg:col-span-2 space-y-6">
+          <div class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+            <h3
+              class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+            >
+              <i class="pi pi-info-circle mr-2 text-blue-600"></i>
+              基本資訊
+            </h3>
+            <div class="space-y-4">
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 mb-2"
+                  for="title"
+                >
+                  商品名稱
+                  <span class="text-red-500 ml-1">*</span>
+                </label>
+                <input
+                  v-model="form.name"
+                  type="text"
+                  id="title"
+                  maxlength="100"
+                  placeholder="請輸入商品名稱"
+                  :class="[
+                    'w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200',
+                    formErrors.name
+                      ? 'border-red-500 bg-red-50'
+                      : 'border-gray-300 hover:border-gray-400',
+                  ]"
+                />
+                <div class="flex justify-between items-center mt-1">
+                  <small v-if="formErrors.name" class="text-red-500">
+                    {{ formErrors.name }}
+                  </small>
+                  <small class="text-gray-500 ml-auto">
+                    {{ form.name.length }}/100
+                  </small>
+                </div>
+              </div>
+
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 mb-2"
+                  for="sku"
+                >
+                  商品貨號
+                  <span class="text-red-500 ml-1">*</span>
+                </label>
+                <input
+                  v-model="form.sku"
+                  type="text"
+                  id="sku"
+                  maxlength="50"
+                  placeholder="例如: PROD-001"
+                  :class="[
+                    'w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200',
+                    formErrors.sku
+                      ? 'border-red-500 bg-red-50'
+                      : 'border-gray-300 hover:border-gray-400',
+                  ]"
+                />
+                <div class="mt-1">
+                  <small v-if="formErrors.sku" class="text-red-500 block">
+                    {{ formErrors.sku }}
+                  </small>
+                  <small class="text-gray-500 text-xs block mt-1">
+                    只能包含英文字母、數字、連字號和底線
+                  </small>
+                </div>
+              </div>
+              <div
+                class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm"
+              >
+                <h3
+                  class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+                >
+                  <i class="pi pi-file-edit mr-2 text-green-600"></i>
+                  商品描述
+                  <span class="text-red-500 ml-1">*</span>
+                </h3>
+                <div
+                  :class="[
+                    'rounded-lg overflow-hidden',
+                    formErrors.description
+                      ? 'border-2 border-red-500'
+                      : 'border border-gray-200',
+                  ]"
+                >
+                  <QuillEditor
+                    v-model:content="form.description"
+                    content-type="html"
+                    :toolbar="toolbarOptions"
+                    theme="snow"
+                    style="height: 300px"
+                    placeholder="請輸入商品描述..."
+                  />
+                </div>
+                <small
+                  v-if="formErrors.description"
+                  class="text-red-500 mt-2 block"
+                >
+                  {{ formErrors.description }}
+                </small>
+              </div>
+
+              <div
+                class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm"
+              >
+                <h3
+                  class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+                >
+                  <i class="pi pi-images mr-2 text-purple-600"></i>
+                  商品圖片
+                </h3>
+                <EditProductImage
+                  :productId="productId"
+                  :pending-images="pendingImages"
+                  :enabled="!!productId"
+                  ref="imageUploaderRef"
+                />
+              </div>
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 mb-2"
+                  for="price"
+                >
+                  商品價格
+                </label>
+                <div class="relative">
+                  <span
+                    class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
+                  >
+                    NT$
+                  </span>
+                  <input
+                    v-model.number="form.price"
+                    type="number"
+                    id="price"
+                    min="0"
+                    max="999999"
+                    step="0.01"
+                    placeholder="0"
+                    :class="[
+                      'w-full pl-12 pr-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200',
+                      formErrors.price
+                        ? 'border-red-500 bg-red-50'
+                        : 'border-gray-300 hover:border-gray-400',
+                    ]"
+                  />
+                </div>
+                <small v-if="formErrors.price" class="text-red-500 mt-1 block">
+                  {{ formErrors.price }}
+                </small>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+            <h3
+              class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+            >
+              <i class="pi pi-box mr-2 text-blue-600"></i>
+              庫存管理
+            </h3>
+            <div class="space-y-4">
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700 mb-2"
+                  for="stock"
+                >
+                  目前庫存數
+                </label>
+                <div class="relative">
+                  <input
+                    v-model.number="form.stockOnHand"
+                    type="number"
+                    id="stock"
+                    min="0"
+                    :disabled="!showStockEdit"
+                    :class="[
+                      'w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200',
+                      formErrors.stockOnHand
+                        ? 'border-red-500 bg-red-50'
+                        : 'border-gray-300 hover:border-gray-400',
+                      !showStockEdit ? 'bg-gray-100 cursor-not-allowed' : '',
+                    ]"
+                  />
+                </div>
+                <small
+                  v-if="formErrors.stockOnHand"
+                  class="text-red-500 mt-1 block"
+                >
+                  {{ formErrors.stockOnHand }}
+                </small>
+              </div>
+
+              <div
+                class="flex items-center space-x-3 p-3 bg-gray-50 rounded-lg"
+              >
+                <Checkbox v-model="showStockEdit" id="stockEdit" binary />
+                <label
+                  class="text-sm font-medium text-gray-700"
+                  for="stockEdit"
+                >
+                  允許修改庫存
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="showStockEdit"
+            class="bg-orange-50 border border-orange-200 rounded-lg p-4 mt-4"
           >
-            商品描述
-          </label>
-          <QuillEditor
-            v-model:content="form.description"
-            content-type="html"
-            :toolbar="toolbarOptions"
-            theme="snow"
-            style="height: 220px"
-            class="rounded-b-lg border-x border-b border-gray-300 bg-gray-50"
-          />
-        </div>
+            <h4 class="font-semibold text-orange-800 mb-3 flex items-center">
+              <i class="pi pi-exclamation-triangle mr-2"></i>
+              庫存修改記錄
+            </h4>
+            <div class="space-y-3">
+              <div>
+                <label class="block text-sm font-medium text-orange-800 mb-2">
+                  修改原因
+                  <span class="text-red-500 ml-1">*</span>
+                </label>
+                <Select
+                  v-model="form.stockEditReason"
+                  :options="stockEditReasonTypes"
+                  optionLabel="title"
+                  optionValue="code"
+                  placeholder="選擇修改原因"
+                  :class="[
+                    'w-full',
+                    formErrors.stockEditReason ? 'border-red-500' : '',
+                  ]"
+                />
+                <small
+                  v-if="formErrors.stockEditReason"
+                  class="text-red-500 mt-1 block"
+                >
+                  {{ formErrors.stockEditReason }}
+                </small>
+              </div>
+              <div class="text-sm text-orange-700 bg-orange-100 p-3 rounded-lg">
+                <i class="pi pi-info-circle mr-1"></i>
+                修改庫存將會記錄在庫存變更歷史中，並可供後續查詢與稽核
+              </div>
+            </div>
+          </div>
 
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="image">
-            商品圖片
-          </label>
-          <UploadFile />
-        </div>
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="price">
-            商品價格
-          </label>
-          <input
-            v-model="form.price"
-            type="number"
-            id="price"
-            min="0"
-            class="bg-gray-50 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary w-full md:w-56 px-4 py-2 text-lg transition"
-          />
-        </div>
+          <div class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+            <h3
+              class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+            >
+              <i class="pi pi-tags mr-2 text-orange-600"></i>
+              商品標籤
+            </h3>
+            <div class="space-y-3">
+              <div class="flex gap-4">
+                <div class="flex-1">
+                  <label class="text-sm text-gray-600 mb-1 block">
+                    標籤類型
+                  </label>
+                  <Select
+                    v-model="selectedType"
+                    :options="types"
+                    optionLabel="name"
+                    placeholder="選擇標籤類型"
+                    class="w-full"
+                  />
+                </div>
+                <div class="flex-2">
+                  <label class="text-sm text-gray-600 mb-1 block">
+                    搜尋標籤
+                  </label>
+                  <AutoComplete
+                    v-model="tagValue"
+                    multiple
+                    fluid
+                    :loading="isSearchingTags"
+                    :typeahead="false"
+                    :suggestions="items"
+                    field="name"
+                    placeholder="輸入標籤名稱搜尋..."
+                    @complete="search"
+                    :disabled="!selectedType"
+                  />
+                </div>
+              </div>
 
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="stock">
-            目前庫存數
-          </label>
-          <div class="flex gap-4 items-end">
-            <input
-              v-model="form.stockOnHand"
-              type="number"
-              id="stock"
-              min="0"
-              disabled
-              class="bg-gray-50 rounded-lg border border-gray-300 focus:outline-none w-full md:w-56 px-4 py-2 text-lg"
-            />
-            <div class="flex items-center">
-              <Checkbox v-model="showStockEdit" id="stockEdit" binary />
-              <label class="ml-2 text-gray-600" for="stockEdit">修改庫存</label>
+              <div v-if="tagValue.length > 0" class="mt-3">
+                <div class="flex items-center justify-between mb-2">
+                  <span class="text-sm font-medium text-gray-700">
+                    已選擇標籤 ({{ tagValue.length }})
+                  </span>
+                  <button
+                    @click="clearAllTags"
+                    type="button"
+                    class="text-sm text-red-600 hover:text-red-800 underline"
+                  >
+                    清除全部
+                  </button>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <div
+                    v-for="tag in tagValue"
+                    :key="tag.code"
+                    class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800 border border-blue-200"
+                  >
+                    <span class="mr-2">{{ tag.name }}</span>
+                    <button
+                      @click="removeTag(tag)"
+                      type="button"
+                      class="flex-shrink-0 ml-1 h-4 w-4 rounded-full inline-flex items-center justify-center text-blue-400 hover:bg-blue-200 hover:text-blue-600 focus:outline-none focus:bg-blue-500 focus:text-white"
+                    >
+                      <svg
+                        class="h-2 w-2"
+                        stroke="currentColor"
+                        fill="none"
+                        viewBox="0 0 8 8"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-width="1.5"
+                          d="m1 1 6 6m0-6-6 6"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="!selectedType"
+                class="text-sm text-gray-500 italic bg-gray-50 p-3 rounded-lg"
+              >
+                <i class="pi pi-info-circle mr-2"></i>
+                請先選擇標籤類型才能搜尋標籤
+              </div>
             </div>
           </div>
         </div>
 
-        <div
-          v-if="showStockEdit"
-          class="shadow-inner px-4 py-6 rounded-lg bg-gray-50"
-        >
-          <label class="font-semibold mb-2 block text-gray-700">
-            修改後庫存
-          </label>
-          <input
-            type="number"
-            v-model="form.stockOnHand"
-            min="0"
-            class="bg-gray-50 rounded-lg border border-gray-300 focus:outline-none w-full md:w-56 px-4 py-2 text-lg"
-          />
-          <label class="font-semibold mb-2 mt-2 block text-gray-700">
-            修改原因
-          </label>
-          <Select
-            v-model="form.stockEditReason"
-            :options="stockEditReasonTypes"
-            optionLabel="title"
-            placeholder="選擇修改原因"
-            class="w-full md:w-56"
-          />
-        </div>
-
-        <div>
-          <label
-            for="multiple-ac-2"
-            class="font-semibold mb-2 block text-gray-700"
-          >
-            商品標籤
-          </label>
-          <div class="flex gap-4">
+        <div class="space-y-6">
+          <div class="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+            <h3
+              class="text-lg font-semibold text-gray-900 mb-4 flex items-center"
+            >
+              <i class="pi pi-flag mr-2 text-red-600"></i>
+              商品狀態
+            </h3>
             <Select
-              v-model="selectedType"
-              :options="types"
+              v-model="form.status"
+              :options="statusOptions"
               optionLabel="name"
-              placeholder="選擇標籤類型"
-              class="w-full md:w-56"
+              optionValue="value"
+              placeholder="選擇商品狀態"
+              class="w-full"
             />
-            <AutoComplete
-              v-model="tagValue"
-              inputId="multiple-ac-2"
-              multiple
-              fluid
-              :typeahead="false"
-              :suggestions="items"
-              field="name"
-              @complete="search"
-            />
+            <div class="mt-3 text-sm text-gray-600">
+              <div class="space-y-1">
+                <div class="flex items-center">
+                  <span class="w-3 h-3 bg-green-500 rounded-full mr-2"></span>
+                  <span>上架中:商品可被搜尋與購買</span>
+                </div>
+                <div class="flex items-center">
+                  <span class="w-3 h-3 bg-yellow-500 rounded-full mr-2"></span>
+                  <span>草稿:不公開顯示，可繼續編輯</span>
+                </div>
+                <div class="flex items-center">
+                  <span class="w-3 h-3 bg-gray-500 rounded-full mr-2"></span>
+                  <span>典藏:已下架，不可購買</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        <div>
-          <label class="font-semibold mb-2 block text-gray-700" for="status">
-            商品狀態
-          </label>
-          <Select
-            v-model="form.status"
-            :options="statusOptions"
-            optionLabel="name"
-            optionValue="value"
-            placeholder="選擇商品狀態"
-            class="w-full md:w-56"
-          />
-        </div>
-        <div class="flex justify-end">
-          <button
-            class="text-md font-bold text-white px-4 py-2 rounded-lg bg-primary shadow-md hover:bg-primary-700 hover:cursor-pointer transition"
-            @click="submit"
-          >
-            儲存商品
-          </button>
+      </div>
+      <div class="sticky bottom-0 bg-white border-t border-gray-200 p-6 mt-8">
+        <div class="flex justify-between items-center max-w-6xl mx-auto">
+          <div class="text-sm text-gray-500">
+            <i class="pi pi-info-circle mr-1"></i>
+            {{
+              isCreateMode
+                ? '請確認所有資訊填寫完整後再建立商品'
+                : '修改後請記得儲存更新'
+            }}
+          </div>
+          <div class="flex gap-3">
+            <Button
+              @click="router.go(-1)"
+              :disabled="isSaving"
+              severity="secondary"
+              outlined
+              class="px-6 py-3 min-w-24 h-12 font-medium hover:shadow-lg transition-all duration-200 border-2"
+              icon="pi pi-arrow-left"
+            >
+              返回
+            </Button>
+            <Button
+              @click="submit"
+              :loading="isSaving"
+              :disabled="isSaving"
+              class="px-8 py-3 min-w-32 h-12 font-semibold text-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105"
+              severity="primary"
+              :icon="isCreateMode ? 'pi pi-plus' : 'pi pi-save'"
+            >
+              <template v-if="!isSaving">
+                {{ isCreateMode ? '建立商品' : '儲存更新' }}
+              </template>
+              <template v-else>
+                {{ isCreateMode ? '建立中...' : '儲存中...' }}
+              </template>
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/Admin/EditProductImage.vue
+++ b/src/views/Admin/EditProductImage.vue
@@ -8,7 +8,12 @@
     deleteProductImage,
   } from '@/api/productImage'
 
-  const props = defineProps({ productId: Number })
+  const props = defineProps({
+    productId: Number,
+    pendingImages: Array,
+    enabled: Boolean,
+  })
+
   const toast = useToast()
 
   const coverImage = ref(null)
@@ -19,6 +24,8 @@
   const MAX_FILE_SIZE_MB = 5
   const MAX_PREVIEW_IMAGES = 3
   const maxPreviewImages = ref(MAX_PREVIEW_IMAGES)
+
+  const internalPendingImages = ref([])
 
   const loadImages = async () => {
     try {
@@ -72,7 +79,11 @@
   const onSelectMainImage = async (e) => {
     const file = e.target.files[0]
     if (file && validateImage(file)) {
-      await upload(file, true)
+      if (!props.productId) {
+        internalPendingImages.value.push({ file, isCover: true })
+      } else {
+        await upload(file, true)
+      }
     }
   }
 
@@ -81,7 +92,11 @@
     const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
     const validFiles = files.filter(validateImage).slice(0, slotsLeft)
     for (const file of validFiles) {
-      await upload(file, false)
+      if (!props.productId) {
+        internalPendingImages.value.push({ file, isCover: false })
+      } else {
+        await upload(file, false)
+      }
     }
   }
 
@@ -89,7 +104,11 @@
     e.preventDefault()
     const file = e.dataTransfer.files[0]
     if (file && validateImage(file)) {
-      await upload(file, true)
+      if (!props.productId) {
+        internalPendingImages.value.push({ file, isCover: true })
+      } else {
+        await upload(file, true)
+      }
     }
   }
 
@@ -99,7 +118,11 @@
     const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
     const validFiles = files.filter(validateImage).slice(0, slotsLeft)
     for (const file of validFiles) {
-      await upload(file, false)
+      if (!props.productId) {
+        internalPendingImages.value.push({ file, isCover: false })
+      } else {
+        await upload(file, false)
+      }
     }
   }
 
@@ -122,6 +145,31 @@
     } finally {
       isUploading.value = false
       checkPreviewLimit()
+    }
+  }
+
+  const uploadPending = async (productId) => {
+    if (!internalPendingImages.value.length) return
+    isUploading.value = true
+    try {
+      for (const item of internalPendingImages.value) {
+        const { file, isCover } = item
+        const formData = new FormData()
+        formData.append('image', file)
+        formData.append('isCover', isCover ? 'true' : 'false')
+        await uploadProductImage(productId, formData)
+      }
+      internalPendingImages.value = []
+      await loadImages()
+    } catch (err) {
+      toast.add({
+        severity: 'error',
+        summary: '圖片上傳失敗',
+        detail: '建立商品成功但圖片未成功上傳',
+        life: 4000,
+      })
+    } finally {
+      isUploading.value = false
     }
   }
 
@@ -148,7 +196,10 @@
   }
 
   const validateBeforeSubmit = () => {
-    if (!coverImage.value) {
+    if (
+      !coverImage.value &&
+      !internalPendingImages.value.some((i) => i.isCover)
+    ) {
       toast.add({
         severity: 'warn',
         summary: '驗證失敗',
@@ -160,10 +211,15 @@
     return true
   }
 
-  onMounted(loadImages)
+  onMounted(() => {
+    if (props.productId) {
+      loadImages()
+    }
+  })
 
   defineExpose({
     validateBeforeSubmit,
+    uploadPending,
   })
 </script>
 
@@ -185,6 +241,7 @@
           class="hidden"
           ref="coverInput"
           @change="onSelectMainImage"
+          name="cover"
         />
       </div>
       <div v-if="coverImage" class="mt-4 relative w-40">
@@ -208,6 +265,7 @@
         @change="onSelectPreviewImages"
         :disabled="overLimit"
         class="block w-full border p-2 rounded cursor-pointer"
+        name="previews"
       />
 
       <div

--- a/src/views/Admin/EditProductImage.vue
+++ b/src/views/Admin/EditProductImage.vue
@@ -1,7 +1,11 @@
 <script setup>
-  import { ref, onMounted } from 'vue'
+  import { ref, onMounted, computed } from 'vue'
   import draggable from 'vuedraggable'
   import { useToast } from 'primevue/usetoast'
+  import ProgressBar from 'primevue/progressbar'
+  import Button from 'primevue/button'
+  import Dialog from 'primevue/dialog'
+  import Image from 'primevue/image'
   import {
     fetchProductImages,
     uploadProductImage,
@@ -20,16 +24,39 @@
   const previewImages = ref([])
   const isUploading = ref(false)
   const overLimit = ref(false)
+  const uploadProgress = ref(0)
+  const showPreview = ref(false)
+  const previewImageUrl = ref('')
+  const maxRetries = 3
 
   const MAX_FILE_SIZE_MB = 5
   const MAX_PREVIEW_IMAGES = 3
-  const maxPreviewImages = ref(MAX_PREVIEW_IMAGES)
+  const SUPPORTED_FORMATS = [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+  ]
+
+  const totalImages = computed(() => {
+    return (
+      (coverImage.value ? 1 : 0) +
+      previewImages.value.length +
+      internalPendingImages.value.length
+    )
+  })
 
   const internalPendingImages = ref([])
 
-  const loadImages = async () => {
+  const loadImages = async (productId = null) => {
+    const targetProductId = productId || props.productId
+    if (!targetProductId) {
+      return
+    }
+
     try {
-      const res = await fetchProductImages(props.productId)
+      const res = await fetchProductImages(targetProductId)
       if (!res || !res.data || !Array.isArray(res.data)) {
         throw new Error('無效的圖片資料')
       }
@@ -37,7 +64,7 @@
       const images = res.data
       coverImage.value = images.find((img) => img.isCover) || null
       previewImages.value = images.filter((img) => !img.isCover)
-    } catch (err) {
+    } catch {
       coverImage.value = null
       previewImages.value = []
       toast.add({
@@ -52,52 +79,125 @@
   }
 
   const validateImage = (file) => {
-    const isImage = file.type.startsWith('image/')
-    const isSizeOK = file.size <= MAX_FILE_SIZE_MB * 1024 * 1024
+    const errors = []
 
-    if (!isImage) {
+    const isValidType =
+      SUPPORTED_FORMATS.includes(file.type) ||
+      file.type.startsWith('image/') ||
+      /\.(jpe?g|png|gif|webp)$/i.test(file.name)
+
+    if (!isValidType) {
+      errors.push(`不支援的檔案格式: ${file.type} (檔名: ${file.name})`)
+    }
+
+    if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      errors.push(`檔案大小超過 ${MAX_FILE_SIZE_MB}MB`)
+    }
+
+    if (file.name.length > 100) {
+      errors.push('檔案名稱過長')
+    }
+
+    if (errors.length > 0) {
       toast.add({
         severity: 'error',
-        summary: '上傳失敗',
-        detail: '檔案類型錯誤，僅接受圖片格式',
-        life: 3000,
-      })
-      return false
-    }
-    if (!isSizeOK) {
-      toast.add({
-        severity: 'warn',
-        summary: '上傳失敗',
-        detail: `圖片大小不可超過 ${MAX_FILE_SIZE_MB}MB`,
-        life: 3000,
+        summary: '檔案驗證失敗',
+        detail: errors.join(', '),
+        life: 4000,
       })
       return false
     }
     return true
   }
 
+  const createImagePreview = (file) => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        if (e.target.result) {
+          resolve(e.target.result)
+        } else {
+          reject(new Error('Failed to read file'))
+        }
+      }
+      reader.onerror = () => {
+        reject(new Error('FileReader error'))
+      }
+      reader.readAsDataURL(file)
+    })
+  }
+
   const onSelectMainImage = async (e) => {
     const file = e.target.files[0]
     if (file && validateImage(file)) {
       if (!props.productId) {
-        internalPendingImages.value.push({ file, isCover: true })
+        try {
+          const preview = await createImagePreview(file)
+          internalPendingImages.value = internalPendingImages.value.filter(
+            (img) => !img.isCover
+          )
+          internalPendingImages.value.push({ file, isCover: true, preview })
+        } catch {
+          toast.add({
+            severity: 'error',
+            summary: '預覽失敗',
+            detail: '無法產生圖片預覽',
+            life: 3000,
+          })
+        }
       } else {
-        await upload(file, true)
+        try {
+          await upload(file, true)
+        } catch {
+          toast.add({
+            severity: 'error',
+            summary: '上傳失敗',
+            detail: '後端服務異常，但圖片預覽功能正常',
+            life: 5000,
+          })
+        }
       }
     }
+    e.target.value = ''
   }
 
   const onSelectPreviewImages = async (e) => {
     const files = Array.from(e.target.files)
-    const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
+    const slotsLeft =
+      MAX_PREVIEW_IMAGES -
+      previewImages.value.length -
+      internalPendingImages.value.filter((img) => !img.isCover).length
+
+    if (slotsLeft <= 0) {
+      toast.add({
+        severity: 'warn',
+        summary: '上傳限制',
+        detail: `最多只能上傳 ${MAX_PREVIEW_IMAGES} 張小圖`,
+        life: 3000,
+      })
+      return
+    }
+
     const validFiles = files.filter(validateImage).slice(0, slotsLeft)
+
     for (const file of validFiles) {
       if (!props.productId) {
-        internalPendingImages.value.push({ file, isCover: false })
+        try {
+          const preview = await createImagePreview(file)
+          internalPendingImages.value.push({ file, isCover: false, preview })
+        } catch {
+          toast.add({
+            severity: 'error',
+            summary: '預覽失敗',
+            detail: `無法產生圖片預覽: ${file.name}`,
+            life: 3000,
+          })
+        }
       } else {
         await upload(file, false)
       }
     }
+    e.target.value = ''
   }
 
   const onDropMain = async (e) => {
@@ -105,7 +205,20 @@
     const file = e.dataTransfer.files[0]
     if (file && validateImage(file)) {
       if (!props.productId) {
-        internalPendingImages.value.push({ file, isCover: true })
+        try {
+          const preview = await createImagePreview(file)
+          internalPendingImages.value = internalPendingImages.value.filter(
+            (img) => !img.isCover
+          )
+          internalPendingImages.value.push({ file, isCover: true, preview })
+        } catch {
+          toast.add({
+            severity: 'error',
+            summary: '預覽失敗',
+            detail: '無法產生圖片預覽',
+            life: 3000,
+          })
+        }
       } else {
         await upload(file, true)
       }
@@ -115,80 +228,220 @@
   const onDropPreviewImages = async (e) => {
     e.preventDefault()
     const files = Array.from(e.dataTransfer.files)
-    const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
+    const slotsLeft =
+      MAX_PREVIEW_IMAGES -
+      previewImages.value.length -
+      internalPendingImages.value.filter((img) => !img.isCover).length
+
+    if (slotsLeft <= 0) {
+      toast.add({
+        severity: 'warn',
+        summary: '上傳限制',
+        detail: `最多只能上傳 ${MAX_PREVIEW_IMAGES} 張小圖`,
+        life: 3000,
+      })
+      return
+    }
+
     const validFiles = files.filter(validateImage).slice(0, slotsLeft)
+
     for (const file of validFiles) {
       if (!props.productId) {
-        internalPendingImages.value.push({ file, isCover: false })
+        try {
+          const preview = await createImagePreview(file)
+          internalPendingImages.value.push({ file, isCover: false, preview })
+        } catch {
+          toast.add({
+            severity: 'error',
+            summary: '預覽失敗',
+            detail: `無法產生圖片預覽: ${file.name}`,
+            life: 3000,
+          })
+        }
       } else {
         await upload(file, false)
       }
     }
   }
 
-  const upload = async (file, isCover) => {
-    const formData = new FormData()
-    formData.append('image', file)
-    formData.append('isCover', isCover ? 'true' : 'false')
-
-    isUploading.value = true
+  const uploadWithRetry = async (
+    file,
+    isCover,
+    currentRetry = 0,
+    productId = null
+  ) => {
     try {
-      await uploadProductImage(props.productId, formData)
-      await loadImages()
+      const formData = new FormData()
+      if (isCover) {
+        formData.append('cover', file)
+      } else {
+        formData.append('previews', file)
+      }
+
+      const targetProductId = productId || props.productId
+      if (!targetProductId) {
+        throw new Error('Product ID is required for upload')
+      }
+
+      const response = await uploadProductImage(targetProductId, formData)
+      return response
     } catch (err) {
+      if (currentRetry < maxRetries) {
+        // console.log(`上傳失敗，第 ${currentRetry + 1} 次重試...`)
+        await new Promise((resolve) =>
+          setTimeout(resolve, 1000 * (currentRetry + 1))
+        )
+        return uploadWithRetry(file, isCover, currentRetry + 1, productId)
+      }
+      throw err
+    }
+  }
+
+  const upload = async (file, isCover) => {
+    isUploading.value = true
+    uploadProgress.value = 0
+
+    try {
+      const progressInterval = setInterval(() => {
+        if (uploadProgress.value < 90) {
+          uploadProgress.value += Math.random() * 10
+        }
+      }, 200)
+
+      await uploadWithRetry(file, isCover, 0)
+      uploadProgress.value = 100
+      clearInterval(progressInterval)
+
+      await loadImages()
+
+      toast.add({
+        severity: 'success',
+        summary: '上傳成功',
+        detail: isCover ? '主圖上傳成功' : '圖片上傳成功',
+        life: 2000,
+      })
+    } catch (uploadError) {
+      let errorMessage = '上傳失敗，請稍後再試'
+
+      if (uploadError.response?.status === 400) {
+        const backendMessage =
+          uploadError.response?.data?.message ||
+          uploadError.response?.data?.error
+        if (backendMessage) {
+          errorMessage = `上傳驗證錯誤：${backendMessage}`
+        } else {
+          errorMessage = '檔案格式或內容有誤'
+        }
+      } else if (uploadError.response?.status === 413) {
+        errorMessage = '檔案大小超過上傳限制'
+      } else if (uploadError.response?.status === 415) {
+        errorMessage = '不支援的檔案格式'
+      } else if (uploadError.response?.status >= 500) {
+        errorMessage = '伺服器錯誤，請稍後再試'
+      }
+
       toast.add({
         severity: 'error',
         summary: '上傳失敗',
-        detail: '請稍後再試或聯絡管理員',
-        life: 3000,
+        detail: errorMessage,
+        life: 5000,
       })
     } finally {
       isUploading.value = false
+      uploadProgress.value = 0
       checkPreviewLimit()
     }
   }
 
   const uploadPending = async (productId) => {
     if (!internalPendingImages.value.length) return
+    if (!productId) {
+      return
+    }
+
     isUploading.value = true
+    uploadProgress.value = 0
+
     try {
-      for (const item of internalPendingImages.value) {
+      const totalFiles = internalPendingImages.value.length
+
+      for (let i = 0; i < totalFiles; i++) {
+        const item = internalPendingImages.value[i]
         const { file, isCover } = item
-        const formData = new FormData()
-        formData.append('image', file)
-        formData.append('isCover', isCover ? 'true' : 'false')
-        await uploadProductImage(productId, formData)
+
+        uploadProgress.value = (i / totalFiles) * 100
+
+        await uploadWithRetry(file, isCover, 0, productId)
       }
+
+      uploadProgress.value = 100
       internalPendingImages.value = []
-      await loadImages()
-    } catch (err) {
+      await loadImages(productId)
+
+      toast.add({
+        severity: 'success',
+        summary: '批量上傳成功',
+        detail: `成功上傳 ${totalFiles} 張圖片`,
+        life: 3000,
+      })
+    } catch {
       toast.add({
         severity: 'error',
-        summary: '圖片上傳失敗',
-        detail: '建立商品成功但圖片未成功上傳',
-        life: 4000,
+        summary: '批量上傳失敗',
+        detail: '部分圖片未能成功上傳，請手動重新上傳',
+        life: 5000,
       })
     } finally {
       isUploading.value = false
+      uploadProgress.value = 0
     }
   }
 
   const deleteImage = async (imageId) => {
+    if (!confirm('確定要刪除這張圖片嗎？')) {
+      return
+    }
+
     isUploading.value = true
     try {
       await deleteProductImage(props.productId, imageId)
       await loadImages()
-    } catch (err) {
+
+      toast.add({
+        severity: 'success',
+        summary: '刪除成功',
+        detail: '圖片已成功刪除',
+        life: 2000,
+      })
+    } catch (deleteError) {
+      let errorMessage = '無法刪除圖片，請稍後再試'
+
+      if (deleteError.response?.status === 403) {
+        errorMessage = '權限不足，無法刪除圖片'
+      } else if (deleteError.response?.status === 404) {
+        errorMessage = '圖片不存在或已被刪除'
+      }
+
       toast.add({
         severity: 'error',
         summary: '刪除失敗',
-        detail: '無法刪除圖片，請稍後再試！',
+        detail: errorMessage,
         life: 3000,
       })
     } finally {
       isUploading.value = false
       checkPreviewLimit()
     }
+  }
+
+  const removePendingImage = (index) => {
+    internalPendingImages.value.splice(index, 1)
+    checkPreviewLimit()
+  }
+
+  const previewImage = (imageUrl) => {
+    previewImageUrl.value = imageUrl
+    showPreview.value = true
   }
 
   const checkPreviewLimit = () => {
@@ -196,18 +449,33 @@
   }
 
   const validateBeforeSubmit = () => {
-    if (
-      !coverImage.value &&
-      !internalPendingImages.value.some((i) => i.isCover)
-    ) {
+    const hasCoverImage =
+      coverImage.value || internalPendingImages.value.some((i) => i.isCover)
+
+    if (!hasCoverImage) {
       toast.add({
         severity: 'warn',
         summary: '驗證失敗',
-        detail: '請上傳封面圖',
+        detail: '請上傳封面圖片',
         life: 3000,
       })
       return false
     }
+
+    const totalPendingImages = internalPendingImages.value.length
+    const totalExistingImages =
+      (coverImage.value ? 1 : 0) + previewImages.value.length
+
+    if (totalPendingImages === 0 && totalExistingImages === 0) {
+      toast.add({
+        severity: 'warn',
+        summary: '驗證失敗',
+        detail: '請至少上傳一張圖片',
+        life: 3000,
+      })
+      return false
+    }
+
     return true
   }
 
@@ -225,86 +493,438 @@
 
 <template>
   <Toast />
-  <div>
-    <div class="mb-6">
-      <label class="block mb-2 text-sm font-medium">主圖</label>
+  <div class="space-y-8">
+    <div
+      class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl border border-blue-200 p-6"
+    >
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center">
+          <div
+            class="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center mr-3"
+          >
+            <i class="pi pi-image text-white text-lg"></i>
+          </div>
+          <div>
+            <h4 class="font-semibold text-gray-900">
+              主圖設定
+              <span class="text-red-500 ml-1">*</span>
+            </h4>
+            <p class="text-sm text-gray-600">商品的主要展示圖片</p>
+          </div>
+        </div>
+        <div class="text-right">
+          <div
+            class="text-xs text-gray-500 bg-white px-3 py-1 rounded-full border"
+          >
+            支援 JPEG, PNG, WebP, GIF
+          </div>
+          <div class="text-xs text-gray-500 mt-1">
+            最大 {{ MAX_FILE_SIZE_MB }}MB
+          </div>
+        </div>
+      </div>
+
       <div
-        class="border p-4 border-dashed rounded bg-gray-50 text-center cursor-pointer"
+        :class="[
+          'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-all duration-300 transform hover:scale-102',
+          coverImage || internalPendingImages.some((img) => img.isCover)
+            ? 'border-green-400 bg-green-50 shadow-lg'
+            : 'border-blue-300 bg-white hover:border-blue-400 hover:bg-blue-50 hover:shadow-md',
+        ]"
         @dragover.prevent
+        @dragenter.prevent
         @drop.prevent="onDropMain"
         @click="$refs.coverInput.click()"
       >
-        <p class="text-gray-500">拖曳或點擊選擇主圖</p>
+        <div
+          v-if="
+            !coverImage && !internalPendingImages.some((img) => img.isCover)
+          "
+        >
+          <div
+            class="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <i class="pi pi-cloud-upload text-2xl text-blue-600"></i>
+          </div>
+          <p class="text-gray-700 font-semibold text-lg mb-2">
+            拖曳或點擊上傳主圖
+          </p>
+          <p class="text-gray-500 text-sm">建議尺寸: 800x800px 或更高解析度</p>
+        </div>
+        <div v-else>
+          <div
+            class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <i class="pi pi-check-circle text-2xl text-green-600"></i>
+          </div>
+          <p class="text-green-700 font-semibold text-lg">主圖已設定</p>
+          <p class="text-green-600 text-sm mt-1">可再次上傳以更換</p>
+        </div>
+
         <input
           type="file"
           accept="image/*"
           class="hidden"
           ref="coverInput"
           @change="onSelectMainImage"
-          name="cover"
         />
       </div>
-      <div v-if="coverImage" class="mt-4 relative w-40">
-        <img :src="coverImage.imgUrl" class="rounded shadow" />
-        <button
-          @click="deleteImage(coverImage.id)"
-          class="absolute top-1 right-1 bg-red-500 text-white p-1 rounded-full"
-        >
-          ✕
-        </button>
+
+      <div class="mt-6">
+        <h5 class="text-sm font-medium text-gray-700 mb-3">主圖預覽</h5>
+        <div class="grid grid-cols-1 gap-4">
+          <div v-if="coverImage" class="flex justify-center">
+            <div class="relative group w-40 h-40">
+              <img
+                :src="coverImage.imgUrl"
+                class="w-full h-full object-cover rounded-xl shadow-lg cursor-pointer transition-transform group-hover:scale-105"
+                @click="previewImage(coverImage.imgUrl)"
+              />
+              <div
+                class="absolute inset-0 bg-opacity-0 group-hover:bg-opacity-40 transition-all rounded-xl flex items-center justify-center"
+              >
+                <div
+                  class="opacity-0 group-hover:opacity-100 transition-opacity flex gap-2"
+                >
+                  <Button
+                    @click.stop="previewImage(coverImage.imgUrl)"
+                    severity="info"
+                    size="small"
+                    class="shadow-lg"
+                    icon="pi pi-eye"
+                    rounded
+                  />
+                  <Button
+                    @click.stop="deleteImage(coverImage.id)"
+                    :disabled="isUploading"
+                    severity="danger"
+                    size="small"
+                    class="shadow-lg"
+                    icon="pi pi-trash"
+                    rounded
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="mt-3 text-center">
+              <span
+                class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800"
+              >
+                <i class="pi pi-star-fill mr-1"></i>
+                主圖
+              </span>
+            </div>
+          </div>
+
+          <div
+            v-for="(item, index) in internalPendingImages.filter(
+              (img) => img.isCover
+            )"
+            :key="'pending-cover-' + index"
+            class="relative group"
+          >
+            <div class="relative w-40 h-40 mx-auto">
+              <img
+                :src="item.preview"
+                :alt="item.file?.name || '預覽圖片'"
+                class="w-full h-full object-cover rounded-xl shadow-lg border-2 border-orange-300 cursor-pointer transition-transform group-hover:scale-105"
+                @click="previewImage(item.preview)"
+                @error="handleImageError"
+                @load="handleImageLoad"
+              />
+              <Button
+                @click.stop="
+                  removePendingImage(
+                    internalPendingImages.findIndex(
+                      (img) => img.isCover && img === item
+                    )
+                  )
+                "
+                severity="danger"
+                size="small"
+                class="absolute top-2 right-2 shadow-lg"
+                icon="pi pi-trash"
+                rounded
+              />
+            </div>
+            <div class="mt-1 text-center">
+              <span
+                class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800"
+              >
+                <i class="pi pi-clock mr-1"></i>
+                待上傳主圖
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
-    <div class="mb-6">
-      <label class="block mb-2 text-sm font-medium">小圖（最多3張）</label>
-      <input
-        type="file"
-        ref="previewInput"
-        multiple
-        accept="image/*"
-        @change="onSelectPreviewImages"
-        :disabled="overLimit"
-        class="block w-full border p-2 rounded cursor-pointer"
-        name="previews"
-      />
-
-      <div
-        class="border p-4 border-dashed rounded bg-gray-50 text-center mt-2"
-        @dragover.prevent
-        @drop.prevent="onDropPreviewImages"
-        @click="$refs.previewInput.click()"
-      >
-        <p class="text-gray-500">拖曳小圖至此處</p>
+    <div
+      class="bg-gradient-to-br from-purple-50 to-pink-50 rounded-xl border border-purple-200 p-6"
+    >
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center">
+          <div
+            class="w-10 h-10 bg-purple-600 rounded-lg flex items-center justify-center mr-3"
+          >
+            <i class="pi pi-images text-white text-lg"></i>
+          </div>
+          <div>
+            <h4 class="font-semibold text-gray-900">
+              小圖集 (最多{{ MAX_PREVIEW_IMAGES }}張)
+            </h4>
+            <p class="text-sm text-gray-600">商品的額外展示圖片</p>
+          </div>
+        </div>
+        <div class="text-right">
+          <div
+            class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
+          >
+            <i class="pi pi-chart-pie mr-1"></i>
+            已上傳:
+            {{
+              previewImages.length +
+              internalPendingImages.filter((img) => !img.isCover).length
+            }}/{{ MAX_PREVIEW_IMAGES }}
+          </div>
+        </div>
       </div>
 
-      <p v-if="overLimit" class="text-red-500 text-sm mt-2">
-        已達上傳上限（最多 {{ maxPreviewImages }} 張）
-      </p>
-
-      <draggable
-        v-model="previewImages"
-        item-key="id"
-        class="grid grid-cols-3 gap-2 mt-4"
+      <div
+        :class="[
+          'border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-all duration-300',
+          overLimit
+            ? 'border-gray-300 bg-gray-100 cursor-not-allowed opacity-60'
+            : 'border-purple-300 bg-white hover:border-purple-400 hover:bg-purple-50 hover:shadow-md transform hover:scale-102',
+        ]"
+        @dragover.prevent
+        @dragenter.prevent
+        @drop.prevent="onDropPreviewImages"
+        @click="!overLimit && $refs.previewInput.click()"
       >
-        <template #item="{ element }">
-          <div class="relative">
-            <img :src="element.imgUrl" class="rounded h-32 object-cover" />
-            <button
-              @click="deleteImage(element.id)"
-              class="absolute top-1 right-1 bg-red-500 text-white p-1 rounded-full"
-            >
-              ✕
-            </button>
+        <div v-if="!overLimit">
+          <div
+            class="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <i class="pi pi-images text-2xl text-purple-600"></i>
           </div>
-        </template>
-      </draggable>
+          <p class="text-gray-700 font-semibold text-lg mb-2">
+            拖曳或點擊上傳小圖
+          </p>
+          <p class="text-gray-500 text-sm">可同時選擇多張圖片</p>
+        </div>
+        <div v-else>
+          <div
+            class="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <i class="pi pi-ban text-2xl text-gray-400"></i>
+          </div>
+          <p class="text-gray-500 font-semibold text-lg">已達上傳上限</p>
+          <p class="text-gray-400 text-sm mt-1">請刪除現有圖片後再上傳新的</p>
+        </div>
+
+        <input
+          type="file"
+          ref="previewInput"
+          multiple
+          accept="image/*"
+          @change="onSelectPreviewImages"
+          :disabled="overLimit"
+          class="hidden"
+        />
+      </div>
+
+      <div
+        v-if="
+          previewImages.length > 0 ||
+          internalPendingImages.filter((img) => !img.isCover).length > 0
+        "
+        class="mt-6"
+      >
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center">
+            <h4 class="text-sm font-semibold text-gray-700">圖片管理</h4>
+            <span
+              class="ml-2 inline-flex items-center px-2 py-1 rounded-full text-xs bg-gray-100 text-gray-600"
+            >
+              <i class="pi pi-sort mr-1"></i>
+              <!-- 可拖曳排序 -->
+            </span>
+          </div>
+        </div>
+
+        <draggable
+          v-model="previewImages"
+          item-key="id"
+          class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"
+        >
+          <template #item="{ element }">
+            <div class="relative group">
+              <div class="relative overflow-hidden rounded-xl">
+                <img
+                  :src="element.imgUrl"
+                  class="w-full h-28 object-cover cursor-pointer transition-all duration-300 group-hover:scale-110"
+                  @click="previewImage(element.imgUrl)"
+                />
+                <div
+                  class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-all duration-300"
+                >
+                  <div
+                    class="absolute bottom-2 left-2 right-2 flex justify-between items-end"
+                  >
+                    <Button
+                      @click.stop="previewImage(element.imgUrl)"
+                      severity="info"
+                      size="small"
+                      class="shadow-lg"
+                      icon="pi pi-eye"
+                      rounded
+                    />
+                    <Button
+                      @click.stop="deleteImage(element.id)"
+                      :disabled="isUploading"
+                      severity="danger"
+                      size="small"
+                      class="shadow-lg"
+                      icon="pi pi-trash"
+                      rounded
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </draggable>
+
+        <div
+          v-if="internalPendingImages.filter((img) => !img.isCover).length > 0"
+          class="mt-3"
+        >
+          <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+            <div
+              v-for="(item, index) in internalPendingImages.filter(
+                (img) => !img.isCover
+              )"
+              :key="'pending-preview-' + index"
+              class="relative group"
+            >
+              <div class="relative">
+                <img
+                  :src="item.preview"
+                  :alt="item.file?.name || '預覽圖片'"
+                  class="w-full h-24 object-cover rounded-lg shadow-sm border-2 border-orange-300 cursor-pointer transition-transform hover:scale-105"
+                  @click="previewImage(item.preview)"
+                  @error="handleImageError"
+                  @load="handleImageLoad"
+                />
+                <Button
+                  @click.stop="
+                    removePendingImage(internalPendingImages.indexOf(item))
+                  "
+                  severity="danger"
+                  size="small"
+                  class="absolute top-1 right-1 shadow-lg"
+                  icon="pi pi-trash"
+                  rounded
+                />
+                <div class="absolute top-1 left-1">
+                  <span
+                    class="text-xs bg-orange-100 text-orange-800 px-1 py-0.5 rounded"
+                  >
+                    待上傳
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div
       v-if="isUploading"
-      class="fixed top-0 left-0 right-0 bg-black bg-opacity-50 text-white text-center py-2 z-50"
+      class="fixed bottom-4 right-4 bg-white border border-blue-200 rounded-xl shadow-2xl p-6 z-50 min-w-80"
     >
-      上傳中，請稍候...
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center">
+          <div
+            class="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center mr-3"
+          >
+            <i class="pi pi-cloud-upload text-blue-600"></i>
+          </div>
+          <span class="text-sm font-semibold text-gray-800">上傳中...</span>
+        </div>
+        <span class="text-sm font-bold text-blue-600">
+          {{ Math.round(uploadProgress) }}%
+        </span>
+      </div>
+      <ProgressBar :value="uploadProgress" class="mb-3 h-2" />
+      <div class="flex items-center text-xs text-gray-600">
+        <i class="pi pi-info-circle mr-1"></i>
+        請勿關閉頁面，上傳完成後會自動更新
+      </div>
+    </div>
+
+    <Dialog
+      v-model:visible="showPreview"
+      modal
+      :style="{ width: '90vw', maxWidth: '800px' }"
+      :maximizable="true"
+      class="image-preview-dialog"
+    >
+      <template #header>
+        <div class="flex items-center">
+          <i class="pi pi-eye mr-2 text-blue-600"></i>
+          <span class="font-bold text-lg">圖片預覽</span>
+        </div>
+      </template>
+      <div class="flex justify-center items-center bg-gray-50 rounded-lg p-4">
+        <Image
+          :src="previewImageUrl"
+          alt="圖片預覽"
+          class="max-w-full max-h-96 rounded-lg shadow-lg"
+          preview
+        />
+      </div>
+      <template #footer>
+        <div class="flex justify-end">
+          <Button
+            label="關閉"
+            icon="pi pi-times"
+            @click="showPreview = false"
+            severity="secondary"
+          />
+        </div>
+      </template>
+    </Dialog>
+    <div
+      v-if="totalImages > 0"
+      class="bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl border p-4"
+    >
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <div
+            class="w-8 h-8 bg-gray-600 rounded-lg flex items-center justify-center mr-3"
+          >
+            <i class="pi pi-chart-bar text-white text-sm"></i>
+          </div>
+          <div>
+            <p class="text-sm font-semibold text-gray-700">圖片統計</p>
+            <p class="text-xs text-gray-500">
+              總圖片數: {{ totalImages }}/{{ MAX_PREVIEW_IMAGES + 1 }}
+            </p>
+          </div>
+        </div>
+        <div v-if="internalPendingImages.length > 0" class="text-right">
+          <span
+            class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800"
+          >
+            <i class="pi pi-clock mr-1"></i>
+            待上傳: {{ internalPendingImages.length }} 張
+          </span>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/views/Admin/EditProductImage.vue
+++ b/src/views/Admin/EditProductImage.vue
@@ -1,0 +1,252 @@
+<script setup>
+  import { ref, onMounted } from 'vue'
+  import draggable from 'vuedraggable'
+  import { useToast } from 'primevue/usetoast'
+  import {
+    fetchProductImages,
+    uploadProductImage,
+    deleteProductImage,
+  } from '@/api/productImage'
+
+  const props = defineProps({ productId: Number })
+  const toast = useToast()
+
+  const coverImage = ref(null)
+  const previewImages = ref([])
+  const isUploading = ref(false)
+  const overLimit = ref(false)
+
+  const MAX_FILE_SIZE_MB = 5
+  const MAX_PREVIEW_IMAGES = 3
+  const maxPreviewImages = ref(MAX_PREVIEW_IMAGES)
+
+  const loadImages = async () => {
+    try {
+      const res = await fetchProductImages(props.productId)
+      if (!res || !res.data || !Array.isArray(res.data)) {
+        throw new Error('無效的圖片資料')
+      }
+
+      const images = res.data
+      coverImage.value = images.find((img) => img.isCover) || null
+      previewImages.value = images.filter((img) => !img.isCover)
+    } catch (err) {
+      coverImage.value = null
+      previewImages.value = []
+      toast.add({
+        severity: 'error',
+        summary: '載入失敗',
+        detail: '無法載入圖片，請稍後再試！',
+        life: 3000,
+      })
+    } finally {
+      checkPreviewLimit()
+    }
+  }
+
+  const validateImage = (file) => {
+    const isImage = file.type.startsWith('image/')
+    const isSizeOK = file.size <= MAX_FILE_SIZE_MB * 1024 * 1024
+
+    if (!isImage) {
+      toast.add({
+        severity: 'error',
+        summary: '上傳失敗',
+        detail: '檔案類型錯誤，僅接受圖片格式',
+        life: 3000,
+      })
+      return false
+    }
+    if (!isSizeOK) {
+      toast.add({
+        severity: 'warn',
+        summary: '上傳失敗',
+        detail: `圖片大小不可超過 ${MAX_FILE_SIZE_MB}MB`,
+        life: 3000,
+      })
+      return false
+    }
+    return true
+  }
+
+  const onSelectMainImage = async (e) => {
+    const file = e.target.files[0]
+    if (file && validateImage(file)) {
+      await upload(file, true)
+    }
+  }
+
+  const onSelectPreviewImages = async (e) => {
+    const files = Array.from(e.target.files)
+    const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
+    const validFiles = files.filter(validateImage).slice(0, slotsLeft)
+    for (const file of validFiles) {
+      await upload(file, false)
+    }
+  }
+
+  const onDropMain = async (e) => {
+    e.preventDefault()
+    const file = e.dataTransfer.files[0]
+    if (file && validateImage(file)) {
+      await upload(file, true)
+    }
+  }
+
+  const onDropPreviewImages = async (e) => {
+    e.preventDefault()
+    const files = Array.from(e.dataTransfer.files)
+    const slotsLeft = MAX_PREVIEW_IMAGES - previewImages.value.length
+    const validFiles = files.filter(validateImage).slice(0, slotsLeft)
+    for (const file of validFiles) {
+      await upload(file, false)
+    }
+  }
+
+  const upload = async (file, isCover) => {
+    const formData = new FormData()
+    formData.append('image', file)
+    formData.append('isCover', isCover ? 'true' : 'false')
+
+    isUploading.value = true
+    try {
+      await uploadProductImage(props.productId, formData)
+      await loadImages()
+    } catch (err) {
+      toast.add({
+        severity: 'error',
+        summary: '上傳失敗',
+        detail: '請稍後再試或聯絡管理員',
+        life: 3000,
+      })
+    } finally {
+      isUploading.value = false
+      checkPreviewLimit()
+    }
+  }
+
+  const deleteImage = async (imageId) => {
+    isUploading.value = true
+    try {
+      await deleteProductImage(props.productId, imageId)
+      await loadImages()
+    } catch (err) {
+      toast.add({
+        severity: 'error',
+        summary: '刪除失敗',
+        detail: '無法刪除圖片，請稍後再試！',
+        life: 3000,
+      })
+    } finally {
+      isUploading.value = false
+      checkPreviewLimit()
+    }
+  }
+
+  const checkPreviewLimit = () => {
+    overLimit.value = previewImages.value.length >= MAX_PREVIEW_IMAGES
+  }
+
+  const validateBeforeSubmit = () => {
+    if (!coverImage.value) {
+      toast.add({
+        severity: 'warn',
+        summary: '驗證失敗',
+        detail: '請上傳封面圖',
+        life: 3000,
+      })
+      return false
+    }
+    return true
+  }
+
+  onMounted(loadImages)
+
+  defineExpose({
+    validateBeforeSubmit,
+  })
+</script>
+
+<template>
+  <Toast />
+  <div>
+    <div class="mb-6">
+      <label class="block mb-2 text-sm font-medium">主圖</label>
+      <div
+        class="border p-4 border-dashed rounded bg-gray-50 text-center cursor-pointer"
+        @dragover.prevent
+        @drop.prevent="onDropMain"
+        @click="$refs.coverInput.click()"
+      >
+        <p class="text-gray-500">拖曳或點擊選擇主圖</p>
+        <input
+          type="file"
+          accept="image/*"
+          class="hidden"
+          ref="coverInput"
+          @change="onSelectMainImage"
+        />
+      </div>
+      <div v-if="coverImage" class="mt-4 relative w-40">
+        <img :src="coverImage.imgUrl" class="rounded shadow" />
+        <button
+          @click="deleteImage(coverImage.id)"
+          class="absolute top-1 right-1 bg-red-500 text-white p-1 rounded-full"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <label class="block mb-2 text-sm font-medium">小圖（最多3張）</label>
+      <input
+        type="file"
+        ref="previewInput"
+        multiple
+        accept="image/*"
+        @change="onSelectPreviewImages"
+        :disabled="overLimit"
+        class="block w-full border p-2 rounded cursor-pointer"
+      />
+
+      <div
+        class="border p-4 border-dashed rounded bg-gray-50 text-center mt-2"
+        @dragover.prevent
+        @drop.prevent="onDropPreviewImages"
+        @click="$refs.previewInput.click()"
+      >
+        <p class="text-gray-500">拖曳小圖至此處</p>
+      </div>
+
+      <p v-if="overLimit" class="text-red-500 text-sm mt-2">
+        已達上傳上限（最多 {{ maxPreviewImages }} 張）
+      </p>
+
+      <draggable
+        v-model="previewImages"
+        item-key="id"
+        class="grid grid-cols-3 gap-2 mt-4"
+      >
+        <template #item="{ element }">
+          <div class="relative">
+            <img :src="element.imgUrl" class="rounded h-32 object-cover" />
+            <button
+              @click="deleteImage(element.id)"
+              class="absolute top-1 right-1 bg-red-500 text-white p-1 rounded-full"
+            >
+              ✕
+            </button>
+          </div>
+        </template>
+      </draggable>
+    </div>
+
+    <div
+      v-if="isUploading"
+      class="fixed top-0 left-0 right-0 bg-black bg-opacity-50 text-white text-center py-2 z-50"
+    >
+      上傳中，請稍候...
+    </div>
+  </div>
+</template>

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -10,6 +10,7 @@
   const product = ref({})
   const quantity = ref(1)
   const inputRef = ref(null)
+  const selectedImageIndex = ref(0)
 
   onMounted(async () => {
     window.scrollTo(0, 0)
@@ -39,6 +40,21 @@
       product.value.isFavorited = originalState
     }
   }
+
+  const selectImage = (index) => {
+    selectedImageIndex.value = index
+  }
+
+  const getCurrentImage = () => {
+    if (!product.value.images) return null
+    const allImages = [product.value.images.cover, ...(product.value.images.previews || [])]
+    return allImages[selectedImageIndex.value] || product.value.images.cover
+  }
+
+  const getTotalImages = () => {
+    if (!product.value.images) return 0
+    return 1 + (product.value.images.previews?.length || 0)
+  }
 </script>
 
 <template>
@@ -46,14 +62,46 @@
     <div class="bg-white shadow-md rounded-lg p-6 md:p-8">
       <div class="flex flex-col md:flex-row gap-10 items-start">
         <div class="w-full md:max-w-[460px] text-center mx-auto">
-          <Image
-            v-if="product.images?.cover"
-            :src="product.images.cover.imgUrl"
-            alt="Product Cover Image"
-            imageClass="w-64 h-64 object-cover rounded mx-auto"
-            preview
-          />
-          <div class="text-sm text-black mt-2">1 / 3</div>
+          <div class="relative inline-block">
+            <Image
+              v-if="getCurrentImage()"
+              :src="getCurrentImage().imgUrl"
+              alt="Product Image"
+              imageClass="w-64 h-64 object-cover rounded mx-auto"
+              preview
+            />
+            <div class="absolute bottom-2 right-2 bg-gray-300 bg-opacity-60 text-white text-xs px-2 py-1 rounded-[100px]">
+              {{ selectedImageIndex + 1 }} / {{ getTotalImages() }}
+            </div>
+          </div>
+          
+          <div v-if="product.images" class="flex justify-center gap-2 mt-4">
+            <div 
+              class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
+              :class="{ 'border-blue-500': selectedImageIndex === 0, 'border-gray-300': selectedImageIndex !== 0 }"
+              @click="selectImage(0)"
+            >
+              <img
+                :src="product.images.cover.imgUrl"
+                alt="Cover thumbnail"
+                class="w-full h-full object-cover"
+              />
+            </div>
+            
+            <div 
+              v-for="(image, index) in product.images.previews || []"
+              :key="image.id"
+              class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
+              :class="{ 'border-blue-500': selectedImageIndex === index + 1, 'border-gray-300': selectedImageIndex !== index + 1 }"
+              @click="selectImage(index + 1)"
+            >
+              <img
+                :src="image.imgUrl"
+                :alt="`Preview thumbnail ${index + 1}`"
+                class="w-full h-full object-cover"
+              />
+            </div>
+          </div>
         </div>
 
         <div class="w-full md:max-w-[360px] mx-auto flex flex-col space-y-4">


### PR DESCRIPTION
### 變更內容

- 新增編輯後台上傳主圖及商品圖，可以新增或是刪除
- 新增單一商品頁小圖輪播欄位
### 驗證方式
1. 後端切到 aws 分支
2. `npm run dev` 開啟本地伺服器
3. 前往 `/admin` 頁面
4. 點擊商品列表編輯現有商品，或是新增商品，上傳圖片
6. 確認資料庫及前台有更新（有新增商品會跑到最後一頁）

### 相關資源
- Closes: #74 

### 備註
- 會再開一個 issue 調整 EditProduct 跟 EditProductImage 的功能 code 移出來