### PR TITLE
feat:Favorite Page 改進與側邊欄優化

### DIFF
--- a/src/api/favorite.js
+++ b/src/api/favorite.js
@@ -1,0 +1,25 @@
+import axios from '@/utils/axiosInstance'
+
+export async function fetchFavorites(token) {
+  const { data } = await axios.get('/favorites', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return data
+}
+
+export async function addToCart(item, token) {
+  return axios.post(
+    '/cart',
+    { productId: item.id, quantity: item.quantity },
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  )
+}
+
+export async function removeFavorite(productId, token) {
+  return axios.delete(`/favorites/${productId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { definePreset } from '@primeuix/themes'
 import Aura from '@primeuix/themes/aura'
 import 'primeicons/primeicons.css'
 import ToastService from 'primevue/toastservice'
+import Toast from 'primevue/toast'
 
 const app = createApp(App)
 const MyPreset = definePreset(Aura, {
@@ -54,6 +55,7 @@ app.use(PrimeVue, {
   },
 })
 app.use(ToastService)
+app.component('Toast', Toast)
 
 const authStore = useAuthStore()
 authStore.initAuth()

--- a/src/views/FavoritePage.vue
+++ b/src/views/FavoritePage.vue
@@ -1,51 +1,129 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import Button from 'primevue/button'
+import Dropdown from 'primevue/dropdown'
+import { useToast } from 'primevue/usetoast'
+import { fetchFavorites, addToCart, removeFavorite } from '@/api/favorite'
+
+const toast = useToast()
+const route = useRoute()
+const favorites = ref([])
+const perPage = 10
+const currentPage = ref(1)
+
+const paginatedFavorites = computed(() => {
+  const start = (currentPage.value - 1) * perPage
+  return favorites.value.slice(start, start + perPage)
+})
+
+const totalPages = computed(() => Math.ceil(favorites.value.length / perPage))
+
+onMounted(async () => {
+  const token = localStorage.getItem('token')
+  try {
+    const data = await fetchFavorites(token)
+    favorites.value = data.map((item) => ({
+      id: item.productId,
+      refId: item.refId,
+      name: item.productName,
+      image: item.thumbnail,
+      price: item.price,
+      quantity: null,
+    }))
+  } catch (err) {
+    toast.add({
+      severity: 'error',
+      summary: '載入失敗',
+      detail: err?.response?.data?.error || '無法取得收藏資料',
+      life: 3000,
+    })
+  }
+})
+
+watch(currentPage, () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+})
+
+async function addToCartHandler(item) {
+  const token = localStorage.getItem('token')
+  try {
+    await addToCart(item, token)
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: '加入失敗',
+      detail: `無法加入購物車：${error.message || '請稍後再試'}`,
+      life: 3000,
+    })
+  }
+}
+
+async function removeFavoriteHandler(productId) {
+  const token = localStorage.getItem('token')
+  try {
+    await removeFavorite(productId, token)
+    favorites.value = favorites.value.filter((f) => f.id !== productId)
+    toast.add({
+      severity: 'success',
+      summary: '已取消收藏',
+      life: 2000,
+    })
+  } catch (err) {
+    toast.add({
+      severity: 'error',
+      summary: '刪除失敗',
+      detail: err?.response?.data?.error || '無法取消收藏',
+      life: 3000,
+    })
+  }
+}
+</script>
+
 <template>
   <div class="bg-gray-50 min-h-screen py-10 px-4">
     <Toast />
-    <div class="max-w-6xl mx-auto flex gap-6">
+    <div class="max-w-6xl mx-auto flex gap-6 items-start">
       <!-- 側邊欄 -->
       <aside class="w-64 bg-white rounded-xl shadow p-6">
         <div class="mb-6 flex items-center gap-3">
-          <div
-            class="w-10 h-10 bg-primary-500 rounded-full flex items-center justify-center"
-          >
+          <div class="w-10 h-10 bg-primary-500 rounded-full flex items-center justify-center">
             <i class="pi pi-user text-white"></i>
           </div>
           <span class="font-bold text-xl text-gray-800">我的帳戶</span>
         </div>
         <nav class="space-y-2">
           <RouterLink
-            to="/profile"
+            to="/userprofile"
             :class="[
-              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
-              route.path === '/profile'
-                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md border-l-4 transition-colors',
+              route.path === '/userprofile'
+                ? 'text-primary-600 bg-primary-50 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 border-transparent',
             ]"
           >
             <i class="pi pi-user"></i>
             個人資料
           </RouterLink>
-
           <RouterLink
             to="/orders"
             :class="[
-              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md border-l-4 transition-colors',
               route.path === '/orders'
-                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+                ? 'text-primary-600 bg-primary-50 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 border-transparent',
             ]"
           >
             <i class="pi pi-shopping-cart"></i>
             訂單中心
           </RouterLink>
-
           <RouterLink
             to="/favorites"
             :class="[
-              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors',
-              route.path === '/Favorites'
-                ? 'text-primary-600 bg-primary-50 border-l-4 border-primary-600'
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100',
+              'flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md border-l-4 transition-colors',
+              route.path === '/favorites'
+                ? 'text-primary-600 bg-primary-50 border-primary-600'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 border-transparent',
             ]"
           >
             <i class="pi pi-heart"></i>
@@ -54,11 +132,9 @@
         </nav>
       </aside>
 
-      <!-- 收藏清單主內容 -->
+      <!-- 主內容 -->
       <div class="flex-1 bg-white rounded-xl shadow p-6">
-        <h2
-          class="text-xl font-semibold mb-4 text-center flex items-center justify-center gap-2"
-        >
+        <h2 class="text-xl font-semibold mb-4 text-center flex items-center justify-center gap-2">
           <i class="pi pi-heart text-gray-400 text-lg"></i>
           我的收藏
         </h2>
@@ -68,20 +144,18 @@
         </div>
 
         <div v-else>
-          <div
-            class="grid grid-cols-12 px-4 py-2 bg-gray-100 text-sm text-gray-600 font-medium rounded-t-xl"
-          >
+          <div class="grid grid-cols-12 px-4 py-2 bg-gray-100 text-sm text-gray-600 font-medium rounded-t-xl">
             <div class="col-span-6 text-center">商品資料</div>
             <div class="col-span-2 text-center">單價</div>
             <div class="col-span-4 text-left pl-12">數量</div>
           </div>
 
           <div
-            v-for="(item, index) in favorites"
+            v-for="(item, index) in paginatedFavorites"
             :key="item.id"
             :class="[
               'grid grid-cols-12 gap-4 px-4 py-4 items-center',
-              index !== favorites.length - 1 ? 'border-b border-gray-200' : '',
+              index !== paginatedFavorites.length - 1 ? 'border-b border-gray-200' : '',
             ]"
           >
             <div class="col-span-6 flex gap-4 items-start">
@@ -92,7 +166,12 @@
               />
               <div>
                 <div class="text-sm text-gray-500">{{ item.refId }}</div>
-                <div class="text-base font-semibold">{{ item.name }}</div>
+                <router-link
+                  :to="`/products/${item.id}`"
+                  class="text-black font-medium text-sm sm:text-base leading-snug hover:underline"
+                >
+                  {{ item.name }}
+                </router-link>
               </div>
             </div>
 
@@ -116,111 +195,52 @@
                 size="small"
                 :disabled="!item.quantity"
                 :class="!item.quantity ? 'opacity-50 cursor-not-allowed' : ''"
-                @click="addToCart(item)"
+                @click="addToCartHandler(item)"
               />
               <Button
                 icon="pi pi-trash"
                 severity="secondary"
                 text
                 size="small"
-                @click="removeFavorite(item.id)"
+                @click="removeFavoriteHandler(item.id)"
               />
             </div>
+          </div>
+
+          <!-- 分頁控制 -->
+          <div class="mt-6 flex justify-center items-center gap-2">
+            <button
+              @click="currentPage > 1 && currentPage--"
+              :disabled="currentPage === 1"
+              class="px-3 py-1 rounded border bg-white text-gray-700 border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+            >
+              上一頁
+            </button>
+
+            <button
+              v-for="page in totalPages"
+              :key="page"
+              @click="currentPage = page"
+              class="px-3 py-1 rounded border"
+              :class="
+                currentPage === page
+                  ? 'bg-primary-500 text-white border-primary-500'
+                  : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100'
+              "
+            >
+              {{ page }}
+            </button>
+
+            <button
+              @click="currentPage < totalPages && currentPage++"
+              :disabled="currentPage === totalPages"
+              class="px-3 py-1 rounded border bg-white text-gray-700 border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+            >
+              下一頁
+            </button>
           </div>
         </div>
       </div>
     </div>
   </div>
 </template>
-
-<script setup>
-  import { ref, onMounted } from 'vue'
-  import { RouterLink, useRoute } from 'vue-router'
-  import Dropdown from 'primevue/dropdown'
-  import Button from 'primevue/button'
-  import axios from 'axios'
-  import { useToast } from 'primevue/usetoast'
-
-  const toast = useToast()
-  const route = useRoute()
-  const favorites = ref([])
-
-  onMounted(async () => {
-    const token = localStorage.getItem('token')
-    try {
-      const { data } = await axios.get('/api/favorites', {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
-
-      favorites.value = data.map((item) => ({
-        id: item.productId,
-        refId: item.refId,
-        name: item.productName,
-        image: item.thumbnail,
-        price: item.price,
-        quantity: null,
-      }))
-    } catch (err) {
-      toast.add({
-        severity: 'error',
-        summary: '載入失敗',
-        detail: err?.response?.data?.error || '無法取得收藏資料',
-        life: 3000,
-      })
-    }
-  })
-
-  async function addToCart(item) {
-    const token = localStorage.getItem('token')
-    try {
-      await axios.post(
-        '/api/cart',
-        {
-          productId: item.id,
-          quantity: item.quantity,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-    } catch (error) {
-      toast.add({
-        severity: 'error',
-        summary: '加入失敗',
-        detail: `無法加入購物車：${error.message || '請稍後再試'}`,
-        life: 3000,
-      })
-    }
-  }
-
-  async function removeFavorite(productId) {
-    const token = localStorage.getItem('token')
-
-    try {
-      await axios.delete(`/api/favorites/${productId}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
-
-      favorites.value = favorites.value.filter((f) => f.id !== productId)
-
-      toast.add({
-        severity: 'success',
-        summary: '已取消收藏',
-        life: 2000,
-      })
-    } catch (err) {
-      toast.add({
-        severity: 'error',
-        summary: '刪除失敗',
-        detail: err?.response?.data?.error || '無法取消收藏',
-        life: 3000,
-      })
-    }
-  }
-</script>

--- a/src/views/NotificationPage.vue
+++ b/src/views/NotificationPage.vue
@@ -1,7 +1,7 @@
 <script setup>
   import { ref, computed, watch, onMounted } from 'vue'
   import Divider from 'primevue/divider'
-  import axios from 'axios'
+  import axios from '@/utils/axiosInstance' 
   import { useNotificationStore } from '@/stores/notifications'
 
   const notificationStore = useNotificationStore()

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -18,7 +18,7 @@
     const id = route.params.id
 
     const token = localStorage.getItem('token')
-    const res = await axios.get(`/api/products/${id}`, {
+    const res = await axios.get(`/products/${id}`, {
       headers: {
         Authorization: token ? `Bearer ${token}` : '',
       },
@@ -55,7 +55,7 @@
     try {
       if (product.value.isFavorited) {
         await axios.post(
-          '/api/favorites',
+          '/favorites',
           { productId },
           { headers: { Authorization: `Bearer ${token}` } }
         )

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -59,11 +59,23 @@
           { productId },
           { headers: { Authorization: `Bearer ${token}` } }
         )
+        toast.add({
+          severity: 'success',
+          summary: '成功加入收藏',
+          detail: '可至「我的收藏」頁面查看此商品',
+          life: 3000,
+        })
       } else {
-        await axios.delete(`favorites/${productId}`)
-, {
-          headers: { Authorization: `Bearer ${token}` }
-        }
+        await axios.delete(`favorites/${productId}`),
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        toast.add({
+          severity: 'error',
+          summary: '已取消收藏',
+          detail: '已從收藏中移除此商品',
+          life: 3000,
+        })
       }
     } catch (err) {
       product.value.isFavorited = originalState
@@ -137,10 +149,20 @@
             />
             <Button
               :label="product.isFavorited ? '已收藏' : '收藏'"
-              icon="pi pi-heart"
-              class="flex-1"
+              class="flex-1 flex items-center justify-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-black border-none"
               @click="toggleFavorite"
-            />
+            >
+              <template #icon>
+                <i
+                  :class="[
+                    product.isFavorited
+                      ? 'pi pi-heart-fill text-red-500'
+                      : 'pi pi-heart text-white',
+                    'text-xl',
+                  ]"
+                />
+              </template>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -60,9 +60,10 @@
           { headers: { Authorization: `Bearer ${token}` } }
         )
       } else {
-        await axios.delete(`/api/favorites/${productId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
+        await axios.delete(`favorites/${productId}`)
+, {
+          headers: { Authorization: `Bearer ${token}` }
+        }
       }
     } catch (err) {
       product.value.isFavorited = originalState

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -4,6 +4,7 @@
   import axios from '@/utils/axiosInstance'
   import Image from 'primevue/image'
   import Button from 'primevue/button'
+  import { useToast } from 'primevue/usetoast'
   import InputNumber from 'primevue/inputnumber'
 
   const route = useRoute()
@@ -15,7 +16,14 @@
     window.scrollTo(0, 0)
 
     const id = route.params.id
-    const res = await axios.get(`/products/${id}`)
+
+    const token = localStorage.getItem('token')
+    const res = await axios.get(`/api/products/${id}`, {
+      headers: {
+        Authorization: token ? `Bearer ${token}` : '',
+      },
+    })
+
     product.value = res.data
 
     await nextTick()
@@ -24,24 +32,52 @@
     }
   })
 
+  const toast = useToast()
   const toggleFavorite = async () => {
     const productId = product.value?.id
     if (!productId) return
+
+    const token = localStorage.getItem('token')
+
+    if (!token) {
+      toast.add({
+        severity: 'warn',
+        summary: '尚未登入',
+        detail: '請先登入才能收藏商品',
+        life: 3000,
+      })
+      return
+    }
 
     const originalState = product.value.isFavorited
     product.value.isFavorited = !originalState
 
     try {
-      await axios.post(`/products/${productId}/favorite`, {
-        favorited: product.value.isFavorited,
-      })
-    } catch {
+      if (product.value.isFavorited) {
+        await axios.post(
+          '/api/favorites',
+          { productId },
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+      } else {
+        await axios.delete(`/api/favorites/${productId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+      }
+    } catch (err) {
       product.value.isFavorited = originalState
+      toast.add({
+        severity: 'error',
+        summary: '收藏操作失敗',
+        detail: err?.response?.data?.error || '請稍後再試',
+        life: 3000,
+      })
     }
   }
 </script>
 
 <template>
+  <Toast />
   <div class="max-w-screen-md mx-auto px-4 py-10 space-y-6">
     <div class="bg-white shadow-md rounded-lg p-6 md:p-8">
       <div class="flex flex-col md:flex-row gap-10 items-start">
@@ -99,7 +135,7 @@
               class="flex-1"
             />
             <Button
-              :label="product.isFavorited ? '取消收藏' : '收藏'"
+              :label="product.isFavorited ? '已收藏' : '收藏'"
               icon="pi pi-heart"
               class="flex-1"
               @click="toggleFavorite"

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -164,7 +164,7 @@
               訂單中心
             </RouterLink>
             <RouterLink
-              to="/"
+              to="/favorites"
               class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-surface-600 hover:text-surface-900 hover:bg-surface-100 rounded-md transition-colors"
             >
               <i class="pi pi-heart"></i>


### PR DESCRIPTION
📌 調整項目

修改側邊欄路由設定，修正導航錯誤
商品詳情頁與收藏功能 API 路徑移除 /api 前綴，串接部署後端
登入後可收藏商品，收藏狀態即時切換
收藏頁面商品名稱可點擊，跳轉至商品詳情頁
收藏頁支援單筆刪除收藏
🧪 測試方式

登入後前往商品詳情頁，可點擊「收藏」或「已收藏」切換收藏狀態
收藏頁面可正常顯示收藏商品
點擊商品名稱可跳轉至詳情頁
點擊垃圾桶 icon 可刪除該筆收藏
確認側邊欄可正確導覽至各頁面