### PR TITLE
fix:修正通知功能的 API 路徑

### DIFF
--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/axiosInstance'
 
 export const useNotificationStore = defineStore('notifications', () => {
   const list = ref([])
@@ -19,10 +19,7 @@ export const useNotificationStore = defineStore('notifications', () => {
   }
 
   async function fetch() {
-    const token = localStorage.getItem('token')
-    const { data } = await axios.get('/api/notifications', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    const { data } = await axios.get('/notifications')
 
     list.value = data.map((item) => ({
       ...item,

--- a/src/views/NotificationPage.vue
+++ b/src/views/NotificationPage.vue
@@ -1,7 +1,7 @@
 <script setup>
   import { ref, computed, watch, onMounted } from 'vue'
   import Divider from 'primevue/divider'
-  import axios from '@/utils/axiosInstance' 
+  import axios from '@/utils/axiosInstance'
   import { useNotificationStore } from '@/stores/notifications'
 
   const notificationStore = useNotificationStore()
@@ -51,7 +51,7 @@
     if (!item.read) {
       try {
         await axios.patch(
-          `/api/notifications/${item.id}/read`,
+          `/notifications/${item.id}/read`,
           {},
           {
             headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
1.修正通知頁中取得與標記已讀的 API 路徑錯誤
2.將通知功能中的 axios 呼叫統一改為使用 @/utils/axiosInstance
3.確保所有請求都帶上 Authorization token
4.前往通知頁面，能成功載入通知
5.進入通知頁不會再噴proxy error