### PR TITLE
fix(order): 修復訂單列表與詳情頁的顯示與搜尋功能

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,3 @@
 VITE_API_BASE_URL='http://localhost:xxxx/xxxx'
+
+https://wanpai-backend.zeabur.app/api

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -11,33 +11,55 @@ export async function fetchOrders(filters = {}) {
       Authorization: `Bearer ${token}`,
     },
   })
+
   return res.data
 }
 
 export async function fetchOrderDetail(orderId) {
-  const res = await axios.get(`/orders/${orderId}`)
-  return res.data
-}
+  const authStore = useAuthStore()
+  const token = authStore.token
 
-export async function fetchAllOrders(status = 'all') {
-  const res = await axios.get('/admin/orders', {
-    params: { status },
+  const res = await axios.get(`/orders/${orderId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   })
   return res.data
 }
 
 export async function createOrder(orderData) {
-  const res = await axios.post('/orders', orderData)
+  const authStore = useAuthStore()
+  const token = authStore.token
+
+  const res = await axios.post('/orders', orderData, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
   return res.data
 }
 
 export async function updateOrder(orderId, updateData) {
-  const res = await axios.put(`/orders/${orderId}`, updateData)
+  const authStore = useAuthStore()
+  const token = authStore.token
+
+  const res = await axios.put(`/orders/${orderId}`, updateData, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
   return res.data
 }
 
 export async function deleteOrder(orderId) {
-  const res = await axios.delete(`/orders/${orderId}`)
+  const authStore = useAuthStore()
+  const token = authStore.token
+
+  const res = await axios.delete(`/orders/${orderId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
   return res.data
 }
 

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -1,7 +1,6 @@
 import axios from '@/utils/axiosInstance'
 import { useAuthStore } from '@/stores/auth'
 
-// for users
 export async function fetchOrders(filters = {}) {
   const authStore = useAuthStore()
   const token = authStore.token
@@ -20,7 +19,6 @@ export async function fetchOrderDetail(orderId) {
   return res.data
 }
 
-// for admin
 export async function fetchAllOrders(status = 'all') {
   const res = await axios.get('/admin/orders', {
     params: { status },

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -1,19 +1,26 @@
 import axios from '@/utils/axiosInstance'
+import { useAuthStore } from '@/stores/auth'
 
 // for users
 export async function fetchOrders(filters = {}) {
+  const authStore = useAuthStore()
+  const token = authStore.token
+
   const res = await axios.get('/orders', {
     params: filters,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   })
   return res.data
 }
 
-// 查詢單一訂單（含明細）
 export async function fetchOrderDetail(orderId) {
   const res = await axios.get(`/orders/${orderId}`)
   return res.data
 }
 
+// for admin
 export async function fetchAllOrders(status = 'all') {
   const res = await axios.get('/admin/orders', {
     params: { status },
@@ -21,32 +28,24 @@ export async function fetchAllOrders(status = 'all') {
   return res.data
 }
 
-// 建立新訂單
 export async function createOrder(orderData) {
-  // orderData 結構範例：
-  // {
-  //   recipientName, recipientPhone, shippingAddress,
-  //   items: [{ productId, productName, productImage, price, quantity, subtotal }, ...]
-  // }
-  const res = await axios.post('/admin/orders', orderData)
+  const res = await axios.post('/orders', orderData)
   return res.data
 }
 
-// 更新訂單狀態（如出貨、取消）
 export async function updateOrder(orderId, updateData) {
-  const res = await axios.put(`/admin/orders/${orderId}`, updateData)
+  const res = await axios.put(`/orders/${orderId}`, updateData)
   return res.data
 }
 
-// 軟刪除訂單
 export async function deleteOrder(orderId) {
-  const res = await axios.delete(`/admin/orders/${orderId}`)
+  const res = await axios.delete(`/orders/${orderId}`)
   return res.data
 }
 
 export function calculateOrdersWithTotal(orders) {
   return orders.map((order) => {
-    const items = order.items || [] // 如果沒有 items 就給空陣列
+    const items = order.items || []
     const total = items.reduce(
       (sum, item) => sum + item.price * item.quantity,
       0

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -8,6 +8,7 @@
 
   const order = ref(null)
   const errorMsg = ref('')
+  const isLoading = ref(true)
 
   onMounted(async () => {
     try {
@@ -15,6 +16,8 @@
       order.value = res.data
     } catch {
       errorMsg.value = '無法取得訂單資料'
+    } finally {
+      isLoading.value = false
     }
   })
 
@@ -50,98 +53,113 @@
 
 <template>
   <div class="p-6 space-y-6 bg-white text-black min-h-screen">
-    <div class="bg-gray-100 p-6 rounded shadow max-w-6xl mx-auto text-center">
-      <h2 class="text-lg font-bold mb-9">訂單進度</h2>
-      <div class="flex justify-between items-center">
-        <div
-          v-for="(step, index) in steps"
-          :key="step.label"
-          class="flex flex-col items-center w-1/4 relative"
-        >
-          <div class="text-sm font-bold mb-2">{{ step.label }}</div>
-          <img
-            :src="step.icon"
-            alt="step icon"
-            class="w-8 h-8 min-w-[32px] min-h-[32px]"
-          />
-          <div class="text-xs text-gray-500 mt-1">{{ step.date }}</div>
-          <template v-if="index < steps.length - 1">
-            <div
-              class="absolute right-[-12%] top-1/2 transform -translate-y-1/2"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                class="w-5 h-5 text-gray-400"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-            </div>
-          </template>
-        </div>
-      </div>
-    </div>
-
-    <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-2">
-      <h2 class="text-lg font-bold mb-2">訂單資訊</h2>
-      <p>訂單編號：{{ order.id }}</p>
-      <p>訂單狀態：{{ order.status }}</p>
-      <p>下單日期：{{ order.date }}</p>
-    </div>
-
-    <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-2">
-      <h2 class="text-lg font-bold mb-2">取貨人資訊</h2>
-      <p>取貨人姓名：{{ order.receiver.name }}</p>
-      <p>聯絡方式：{{ order.receiver.phone }}</p>
-      <p>地址：{{ order.receiver.address }}</p>
-    </div>
-
-    <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-4">
-      <h2 class="text-lg font-bold mb-2">購買商品</h2>
-      <ul>
-        <li
-          v-for="(item, index) in order.items"
-          :key="index"
-          class="flex items-center gap-4 pb-3"
-        >
-          <img
-            :src="item.image"
-            class="w-20 h-20 object-cover rounded border"
-          />
-          <div class="flex-1">
-            <p class="font-medium">{{ item.name }}</p>
-            <p class="text-sm text-gray-600">
-              數量：{{ item.quantity }}，售價：{{ item.price }} 元
-            </p>
-          </div>
-        </li>
-      </ul>
-
-      <div class="border-t pt-4 text-right space-y-2">
-        <div class="p-3 flex justify-between items-center">
-          <p class="text-sm text-gray-500 mt-2 text-left">
-            * 如需更改訂單內容，請聯絡客服處理
-          </p>
-          <p class="text-lg font-bold">總金額：{{ order.total }} 元</p>
-        </div>
-        <div v-if="order.returnStatus !== '未申請'" class="mr-3">
-          <p class="font-semibold">退貨狀態：{{ order.returnStatus }}</p>
-          <p v-if="order.returnReason">原因：{{ order.returnReason }}</p>
-        </div>
-        <div v-else>
-          <button
-            class="px-3 py-1 text-gray-500 rounded hover:bg-gray-100 transition"
-            @click="applyReturn"
+    <div v-if="order">
+      <div class="bg-gray-100 p-6 rounded shadow max-w-6xl mx-auto text-center">
+        <h2 class="text-lg font-bold mb-9">訂單進度</h2>
+        <div class="flex justify-between items-center">
+          <div
+            v-for="(step, index) in steps"
+            :key="step.label"
+            class="flex flex-col items-center w-1/4 relative"
           >
-            申請退貨
-          </button>
+            <div class="text-sm font-bold mb-2">{{ step.label }}</div>
+            <img
+              :src="step.icon"
+              alt="step icon"
+              class="w-8 h-8 min-w-[32px] min-h-[32px]"
+            />
+            <div class="text-xs text-gray-500 mt-1">{{ step.date }}</div>
+            <template v-if="index < steps.length - 1">
+              <div
+                class="absolute right-[-12%] top-1/2 transform -translate-y-1/2"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  class="w-5 h-5 text-gray-400"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-2">
+        <h2 class="text-lg font-bold mb-2">訂單資訊</h2>
+        <p>訂單編號：{{ order.id }}</p>
+        <p>訂單狀態：{{ order.status }}</p>
+        <p>下單日期：{{ order.date }}</p>
+      </div>
+
+      <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-2">
+        <h2 class="text-lg font-bold mb-2">取貨人資訊</h2>
+        <p>取貨人姓名：{{ order.receiver.name }}</p>
+        <p>聯絡方式：{{ order.receiver.phone }}</p>
+        <p>地址：{{ order.receiver.address }}</p>
+      </div>
+
+      <div class="bg-white rounded shadow p-4 max-w-6xl mx-auto space-y-4">
+        <h2 class="text-lg font-bold mb-2">購買商品</h2>
+        <ul>
+          <li
+            v-for="(item, index) in order.items"
+            :key="index"
+            class="flex items-center gap-4 pb-3"
+          >
+            <img
+              :src="item.productImage"
+              class="w-20 h-20 object-cover rounded border"
+            />
+            <div class="flex-1">
+              <p class="font-medium">{{ item.name }}</p>
+              <p class="text-sm text-gray-600">
+                數量：{{ item.quantity }}，售價：{{ item.price }} 元
+              </p>
+            </div>
+          </li>
+        </ul>
+
+        <div class="border-t pt-4 text-right space-y-2">
+          <div class="p-3 flex justify-between items-center">
+            <p class="text-sm text-gray-500 mt-2 text-left">
+              * 如需更改訂單內容，請聯絡客服處理
+            </p>
+            <div class="text-right space-y-1">
+              <p v-if="order.shippingFee" class="text-sm text-gray-600">
+                運費：{{ order.shippingFee }} 元
+              </p>
+              <p class="text-lg font-bold">
+                總金額：{{ (order.total || 0) + (order.shippingFee || 0) }} 元
+              </p>
+            </div>
+          </div>
+
+          <div v-if="order.returnStatus !== '未申請'" class="mr-3">
+            <p class="font-semibold">退貨狀態：{{ order.returnStatus }}</p>
+            <p v-if="order.returnReason">原因：{{ order.returnReason }}</p>
+          </div>
+          <div v-else>
+            <button
+              class="px-3 py-1 text-gray-500 rounded hover:bg-gray-100 transition"
+              @click="applyReturn"
+            >
+              申請退貨
+            </button>
+          </div>
         </div>
       </div>
     </div>
+
+    <div v-else-if="errorMsg" class="text-red-500 text-center">
+      {{ errorMsg }}
+    </div>
+    <div v-if="isloading" class="text-center text-gray-500">資料載入中...</div>
   </div>
 </template>

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -1,9 +1,22 @@
 <script setup>
-  import { ref } from 'vue'
+  import axios from '@/utils/axiosInstance'
+  import { ref, onMounted } from 'vue'
   import { useRoute } from 'vue-router'
 
   const route = useRoute()
   const orderId = route.params.id
+
+  const order = ref(null)
+  const errorMsg = ref('')
+
+  onMounted(async () => {
+    try {
+      const res = await axios.get(`/orders/${orderId}`)
+      order.value = res.data
+    } catch {
+      errorMsg.value = '無法取得訂單資料'
+    }
+  })
 
   const steps = [
     {
@@ -28,40 +41,8 @@
     },
   ]
 
-  const order = ref({
-    id: orderId,
-    date: '2025-05-26',
-    status: '待出貨',
-    total: 960,
-    returnStatus: '未申請',
-    returnReason: '',
-    items: [
-      {
-        name: '可愛娃娃',
-        quantity: 2,
-        price: 300,
-        image:
-          'https://primefaces.org/cdn/primevue/images/product/bamboo-watch.jpg',
-      },
-      {
-        name: '吉伊卡哇',
-        quantity: 3,
-        price: 120,
-        image:
-          'https://primefaces.org/cdn/primevue/images/product/black-watch.jpg',
-      },
-    ],
-    receiver: {
-      name: '林雨',
-      phone: '0900-123-456',
-      shop: '全家便利商店',
-      branch: '信義威秀店',
-      address: '台北市信義區松壽路 20 號',
-      pickupDeadline: '2025-06-02',
-    },
-  })
-
   function applyReturn() {
+    if (!order.value) return
     order.value.returnStatus = '已申請'
     order.value.returnReason = '商品有瑕疵'
   }

--- a/src/views/OrderManagement.vue
+++ b/src/views/OrderManagement.vue
@@ -1,5 +1,4 @@
 <script setup>
-  import axios from '@/utils/axiosInstance'
   import { ref, computed, onMounted, watch } from 'vue'
   import InputText from 'primevue/inputtext'
   import Select from 'primevue/select'
@@ -63,7 +62,6 @@
 
   function goToDetail(id) {
     if (!id || isNaN(Number(id))) {
-      console.warn('⚠️ 訂單 ID 無效:', id)
       return
     }
     router.push(`/orderdetail/${id}`)
@@ -71,9 +69,9 @@
 </script>
 
 <template>
-  <div v-if="authStore.isLoggedIn" class="p-8 max-w-screen-xl mx-auto">
-    <div class="mb-6 flex md:flex-row md:items-end gap-4 justify-end ml-auto">
-      <div class="flex flex-col w-full md:w-[230px]">
+  <div v-if="authStore.isLoggedIn" class="p-8 max-w-6xl mx-auto items-center">
+    <div class="mb-6 flex md:flex-row md:items-end gap-4 justify-end">
+      <div class="flex flex-col w-full md:w-[260px]">
         <label for="orderId" class="text-sm mb-1">訂單搜尋</label>
         <InputText
           id="orderId"
@@ -83,7 +81,7 @@
         />
       </div>
 
-      <div class="flex flex-col w-full md:w-[230px]">
+      <div class="flex flex-col w-full md:w-[260px]">
         <label for="dateRange" class="text-sm mb-1">日期</label>
         <Select
           id="dateRange"
@@ -100,56 +98,74 @@
     <div v-if="errorMsg" class="mb-4 px-4 py-2 text-red-700 rounded border">
       {{ errorMsg }}
     </div>
-    <h2 class="text-2xl mb-6">我的訂單</h2>
-    <DataTable
-      v-model:expandedRows="expandedRows"
-      :value="filteredOrders"
-      dataKey="id"
-      expandableRows
-      tableStyle="min-width: 60rem"
-      :pt="{ bodyRow: { class: 'h-16' } }"
-    >
-      <Column expander style="width: 3rem" />
-      <Column field="id" header="訂單編號" />
-      <Column field="date" header="訂購日期" />
-      <Column field="status" header="狀態" />
-      <Column field="total" header="總金額" />
-      <Column header="">
-        <template #body="slotProps">
-          <Button
-            label="查看詳情"
-            icon="pi pi-search"
-            @click="goToDetail(slotProps.data.id)"
-          />
-        </template>
-      </Column>
 
-      <template #expansion="slotProps">
-        <div class="p-4 bg-gray-50 rounded">
-          <h3 class="font-semibold mb-2">商品明細</h3>
-          <ul>
-            <li
-              v-for="item in slotProps.data.items"
-              :key="item.name"
-              class="flex items-center mb-2 gap-4"
-            >
-              <img
-                :src="item.image"
-                alt="product"
-                class="w-16 h-16 rounded border"
+    <h2 class="text-2xl mb-6">我的訂單</h2>
+
+    <div
+      class="rounded-xl shadow border border-gray-200 overflow-hidden w-full max-w-6xl mx-auto"
+    >
+      <DataTable
+        v-model:expandedRows="expandedRows"
+        :value="filteredOrders"
+        dataKey="id"
+        expandableRows
+        tableStyle="width: 100%"
+        :pt="{ bodyRow: { class: 'h-8' } }"
+      >
+        <Column expander />
+        <Column field="orderNumber" header="訂單編號" style="width: 300px" />
+        <Column field="date" header="訂購日期" style="width: 300px" />
+        <Column field="status" header="狀態" style="width: 240px" />
+        <Column
+          field="total"
+          header="總金額"
+          style="width: 260px"
+          :pt="{
+            bodyCell: { class: 'text-center ' },
+            headerCell: { class: 'text-center ' },
+          }"
+        />
+        <Column header="" style="width: 200px">
+          <template #body="slotProps">
+            <div class="flex justify-start py-1">
+              <Button
+                label="查看訂單"
+                icon="pi pi-search"
+                class="text-xs py-1 rounded shadow"
+                @click="goToDetail(slotProps.data.id)"
               />
-              <div class="flex-1">
-                <div class="font-medium">{{ item.name }}</div>
-                <div class="text-sm text-gray-600">
-                  數量：{{ item.quantity }} ｜ 售價：{{ item.price }} 元
+            </div>
+          </template>
+        </Column>
+
+        <template #expansion="slotProps">
+          <div class="p-4 bg-gray-50 rounded">
+            <h3 class="font-semibold mb-2">商品明細</h3>
+            <ul>
+              <li
+                v-for="item in slotProps.data.items"
+                :key="item.name"
+                class="flex items-center mb-2 gap-4"
+              >
+                <img
+                  :src="item.image"
+                  alt="product"
+                  class="w-16 h-16 rounded border"
+                />
+                <div class="flex-1">
+                  <div class="font-medium">{{ item.name }}</div>
+                  <div class="text-sm text-gray-600">
+                    數量：{{ item.quantity }} ｜ 售價：{{ item.price }} 元
+                  </div>
                 </div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </template>
-    </DataTable>
+              </li>
+            </ul>
+          </div>
+        </template>
+      </DataTable>
+    </div>
   </div>
+
   <div v-else class="flex flex-col items-center justify-center py-24">
     <i
       class="pi pi-info-circle mb-4"

--- a/src/views/OrderManagement.vue
+++ b/src/views/OrderManagement.vue
@@ -1,4 +1,5 @@
 <script setup>
+  import axios from '@/utils/axiosInstance'
   import { ref, computed, onMounted, watch } from 'vue'
   import InputText from 'primevue/inputtext'
   import Select from 'primevue/select'
@@ -52,6 +53,8 @@
     const today = new Date()
     return ordersWithTotal.value.filter((order) => {
       const orderDate = new Date(order.date)
+      if (isNaN(orderDate)) return false
+
       const diffTime = today - orderDate
       const diffDays = diffTime / (1000 * 60 * 60 * 24)
       return diffDays <= parseInt(selectedDateRange.value)
@@ -59,6 +62,10 @@
   })
 
   function goToDetail(id) {
+    if (!id || isNaN(Number(id))) {
+      console.warn('⚠️ 訂單 ID 無效:', id)
+      return
+    }
     router.push(`/orderdetail/${id}`)
   }
 </script>


### PR DESCRIPTION
- 修復訂單列表無法正確載入資料的問題（補上 token 驗證）
- 修復搜尋欄無法正確篩選訂單編號（後端支援模糊搜尋）
- 修復訂單詳情頁無法載入資料（補上 token）
- 調整訂單詳情頁與表格部分樣式，使版面更整齊


請先合併後端 # 100再測試此pr畫面
否則需要同時開前後端環境變數設本地測試

close#102  