### PR TITLE
fix: 在購物車結帳流程中自動載入個人資料

### DIFF
--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -393,13 +393,13 @@ onMounted(async () => {
         <div class="flex flex-col gap-2">
           <label for="username" class="font-bold">姓名</label>
           <InputText id="username" v-model="shippingForm.recipientName" aria-describedby="username-help"
-            class="w-lg p-2 outline rounded-lg" required="" />
+            class="w-lg p-2 outline rounded-lg max-w-full" required="" />
           <label for="cellphone" class="font-bold">手機號碼</label>
           <InputText id="cellphone" v-model="shippingForm.recipientPhone" aria-describedby="cellphone-help"
-            class="w-lg p-2 outline rounded-lg mg-1" required="" />
+            class="w-lg p-2 outline rounded-lg mg-1 max-w-full" required="" />
           <label for="address" class="font-bold">地址</label>
           <InputText id="address" v-model="shippingForm.shippingAddress" aria-describedby="address-help"
-            class="w-lg p-2 outline rounded-lg" required="" />
+            class="w-lg p-2 outline rounded-lg max-w-full" required="" />
         </div>
 
         <div class="flex justify-between items-center pt-2 border-t mt-4">

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -16,6 +16,7 @@ import { useAuthStore } from '@/stores/auth'
 import Button from '@/volt/Button.vue'
 import InputText from 'primevue/inputtext'
 import { showToast } from '@/utils/toast'
+import axios from '@/utils/axiosInstance'
 
 const cart = useCartStore()
 const router = useRouter()
@@ -23,6 +24,7 @@ const authStore = useAuthStore()
 
 const selectedItems = ref([])
 const showShippingDetails = ref(false)
+const profileLoading = ref(false)
 
 const shippingForm = reactive({
   recipientName: '',
@@ -116,6 +118,27 @@ function toggleSelectAll(event) {
   }
 }
 
+  async function loadUserProfile() {
+    try {
+      profileLoading.value = true
+      const response = await axios.get('users/profile')
+      const profile = response.data
+      if (profile) {
+        shippingForm.recipientPhone = profile.phone || ''
+        shippingForm.shippingAddress = profile.address || ''
+      }
+    } catch {
+      showToast({
+      severity: 'error',
+      summary: '輸入錯誤',
+      detail: '收件人姓名不能為空，並至少輸入兩個中文字！',
+    })
+    } finally {
+      profileLoading.value = false
+    }
+  }
+
+
 async function ecpayCheckout() {
   if (!isRecipientNameValid.value) {
     showToast({
@@ -150,7 +173,7 @@ async function ecpayCheckout() {
       summary: '請先登入',
       detail: '請先登入會員再進行結帳！',
     })
-    router.push('/login')
+    router.push('/authform')
     return
   }
 
@@ -222,6 +245,7 @@ function contactDetails() {
     })
   } else {
     showShippingDetails.value = true
+    loadUserProfile()
     nextTick(() => {
       if (shippingDetailsMove.value) {
         shippingDetailsMove.value.scrollIntoView({ behavior: 'smooth' })


### PR DESCRIPTION
### 變更內容

點擊「輸入詳細資訊」時自動調用個人資料 API
自動將手機號碼和地址填入表單
所有欄位仍可自由修改
修正手機版input框會爆版問題

測試方法
登入後在個人資料頁面點選編輯填入手機號碼及地址
到購物車勾選商品點選輸入詳細資訊就會自動帶入個人資料
close:[feat: 在購物車輸入詳細資訊自動載入個人資料](https://github.com/wanpai-app/frontend/issues/119)

<img width="1435" alt="截圖 2025-06-30 下午4 46 57" src="https://github.com/user-attachments/assets/dd9a390a-36f0-4243-95b6-a027bfb932d7" />
