### PR TITLE
fix: 一些零碎 bugs

### DIFF
--- a/src/components/BaseLoader.vue
+++ b/src/components/BaseLoader.vue
@@ -5,7 +5,7 @@
   })
 </script>
 
-<template>
+<!-- <template>
   <div
     v-if="!hasLoadedOnce || isLoading"
     class="text-center text-gray-500 py-10"
@@ -15,4 +15,15 @@
       <p>載入中...</p>
     </slot>
   </div>
+</template> -->
+
+<template>
+  <div
+    v-if="isLoading || !hasLoadedOnce"
+    class="text-center text-gray-500 py-10"
+  >
+    <i class="pi pi-spin pi-spinner text-2xl mb-2"></i>
+    <p>載入中...</p>
+  </div>
+  <slot v-else />
 </template>

--- a/src/components/UserSideBar.vue
+++ b/src/components/UserSideBar.vue
@@ -37,7 +37,7 @@
             : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 border-transparent pl-3 translate-x-0',
         ]"
       >
-        <i class="pi pi-shopping-cart"></i>
+        <i class="pi pi-list"></i>
         訂單中心
       </RouterLink>
 

--- a/src/components/layout/NavBar.vue
+++ b/src/components/layout/NavBar.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { ref, onMounted, watch } from 'vue'
+  import { ref, watch } from 'vue'
   import { RouterLink, useRoute, useRouter } from 'vue-router'
   import Drawer from 'primevue/drawer'
   import Button from 'primevue/button'
@@ -65,6 +65,8 @@
   watch(
     () => authStore.isLoggedIn,
     (isLoggedIn) => {
+      if (!authStore.isInitialized) return
+
       if (isLoggedIn) {
         cart.fetchCart().catch(() => {
           showToast({
@@ -79,18 +81,6 @@
     },
     { immediate: true }
   )
-
-  onMounted(() => {
-    if (authStore.isLoggedIn) {
-      cart.fetchCart().catch(() => {
-        showToast({
-          severity: 'warn',
-          summary: '載入失敗',
-          detail: '購物車資料載入失敗，請重新整理頁面',
-        })
-      })
-    }
-  })
 
   authStore.initAuth()
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -6,6 +6,7 @@ export const useAuthStore = defineStore('auth', {
     isLoggedIn: false,
     token: null,
     role: null,
+    isInitialized: false,
   }),
 
   getters: {
@@ -20,7 +21,17 @@ export const useAuthStore = defineStore('auth', {
       const role = localStorage.getItem('role')
       this.token = token
       this.role = role
-      this.isLoggedIn = token !== null
+      if (token) {
+        try {
+          this.isLoggedIn = true
+        } catch {
+          this.logout()
+        }
+      } else {
+        this.isLoggedIn = false
+      }
+
+      this.isInitialized = true
     },
 
     login(token, role = null) {
@@ -31,6 +42,7 @@ export const useAuthStore = defineStore('auth', {
       this.token = token
       this.role = role
       this.isLoggedIn = true
+      this.isInitialized = true
     },
 
     logout() {
@@ -39,7 +51,7 @@ export const useAuthStore = defineStore('auth', {
       this.token = null
       this.role = null
       this.isLoggedIn = false
-
+      this.isInitialized = true
       const cartStore = useCartStore()
       cartStore.items = []
     },

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -4,8 +4,11 @@
   import { fetchAllProducts } from '@/api/product'
   import { onMounted } from 'vue'
   import { useRouter } from 'vue-router'
+  import BaseLoader from '@/components/BaseLoader.vue'
   import { ref } from 'vue'
   const router = useRouter()
+  const isloading = ref(true)
+  const hasLoadedOnce = ref(false)
   const inventoryTabs = ref([
     { title: '全部', value: 'all' },
     { title: '上架中', value: 'active' },
@@ -48,37 +51,43 @@
   onMounted(async () => {
     const res = await fetchAllProducts()
     productValue.value = res
+    isloading.value = false
+    hasLoadedOnce.value = true
   })
 </script>
 
 <template>
-  <div class="flex justify-between items-center mr-8 mb-4">
-    <h2 class="text-2xl">庫存</h2>
-  </div>
-  <CommonTable
-    :tabs="inventoryTabs"
-    :columns="inventoryColumns"
-    :value="productValue"
-    scrollable
-    selectable
-    scroll-height="500px"
-  >
-    <template #body-coverImage="{ data }">
-      <Image
-        v-if="data.coverImage"
-        :src="data.coverImage"
-        alt="Product Cover Image"
-        imageClass="w-32 h-32 object-cover rounded mx-auto"
-        loading="lazy"
-      />
-    </template>
-    <template #body-name="{ data }">
-      <a
-        class="w-full underline text-primary cursor-pointer"
-        @click="goStockLog(data.id)"
+  <BaseLoader :isLoading="isloading" :hasLoadedOnce="hasLoadedOnce">
+    <div v-if="!isloading">
+      <div class="flex justify-between items-center mr-8 mb-4">
+        <h2 class="text-2xl">庫存</h2>
+      </div>
+      <CommonTable
+        :tabs="inventoryTabs"
+        :columns="inventoryColumns"
+        :value="productValue"
+        scrollable
+        selectable
+        scroll-height="500px"
       >
-        {{ data.name }}
-      </a>
-    </template>
-  </CommonTable>
+        <template #body-coverImage="{ data }">
+          <Image
+            v-if="data.coverImage"
+            :src="data.coverImage"
+            alt="Product Cover Image"
+            imageClass="w-32 h-32 object-cover rounded mx-auto"
+            loading="lazy"
+          />
+        </template>
+        <template #body-name="{ data }">
+          <a
+            class="w-full underline text-primary cursor-pointer"
+            @click="goStockLog(data.id)"
+          >
+            {{ data.name }}
+          </a>
+        </template>
+      </CommonTable>
+    </div>
+  </BaseLoader>
 </template>

--- a/src/views/Admin/AdminOrders.vue
+++ b/src/views/Admin/AdminOrders.vue
@@ -5,7 +5,10 @@
   import { useRouter } from 'vue-router'
   import CommonTable from '@/components/CommonTable.vue'
   import { showToast } from '@/utils/toast'
+  import BaseLoader from '@/components/BaseLoader.vue'
   const router = useRouter()
+  const isloading = ref(true)
+  const hasLoadedOnce = ref(false)
 
   const orderTabs = ref([
     { title: '全部', value: 'all' },
@@ -86,36 +89,42 @@
   onMounted(async () => {
     const res = await fetchAllOrders()
     orderValue.value = res
+    isloading.value = false
+    hasLoadedOnce.value = true
   })
 </script>
 
 <template>
   <Toast />
-  <div class="flex justify-between items-center mr-8 mb-4">
-    <h2 class="text-2xl">訂單</h2>
-  </div>
-  <div class="mr-8">
-    <CommonTable
-      :tabs="orderTabs"
-      :columns="orderColumns"
-      :value="orderValue"
-      @tab-change="handleTabChange"
-      scrollable
-      selectable
-      scroll-height="500px"
-    >
-      <template #body-orderNumber="{ data }">
-        <a
-          class="w-full underline text-primary cursor-pointer"
-          @click="
-            router.push({
-              path: `/admin/orders/edit/${data.id}`,
-            })
-          "
+  <BaseLoader :isLoading="isloading" :hasLoadedOnce="hasLoadedOnce">
+    <div v-if="!isloading">
+      <div class="flex justify-between items-center mr-8 mb-4">
+        <h2 class="text-2xl">訂單</h2>
+      </div>
+      <div class="mr-8">
+        <CommonTable
+          :tabs="orderTabs"
+          :columns="orderColumns"
+          :value="orderValue"
+          @tab-change="handleTabChange"
+          scrollable
+          selectable
+          scroll-height="500px"
         >
-          {{ data.orderNumber }}
-        </a>
-      </template>
-    </CommonTable>
-  </div>
+          <template #body-orderNumber="{ data }">
+            <a
+              class="w-full underline text-primary cursor-pointer"
+              @click="
+                router.push({
+                  path: `/admin/orders/edit/${data.id}`,
+                })
+              "
+            >
+              {{ data.orderNumber }}
+            </a>
+          </template>
+        </CommonTable>
+      </div>
+    </div>
+  </BaseLoader>
 </template>

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -4,9 +4,12 @@
   import { fetchAllProducts } from '@/api/product'
   import { onMounted } from 'vue'
   import { useRouter } from 'vue-router'
+  import BaseLoader from '@/components/BaseLoader.vue'
   import Toast from 'primevue/toast'
   import Image from 'primevue/image'
   const router = useRouter()
+  const isloading = ref(true)
+  const hasLoadedOnce = ref(false)
 
   const productTabs = ref([
     { title: '全部', value: 'all' },
@@ -55,49 +58,55 @@
   onMounted(async () => {
     const res = await fetchAllProducts()
     productValue.value = res
+    isloading.value = false
+    hasLoadedOnce.value = true
   })
 </script>
 
 <template>
   <Toast />
-  <div class="flex justify-between items-center mr-8 mb-4">
-    <h2 class="text-2xl">商品</h2>
-    <div class="card flex justify-center">
-      <button
-        class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
-        @click="goCreateProduct"
-      >
-        新增商品
-      </button>
-    </div>
-  </div>
-  <div class="mr-8">
-    <CommonTable
-      :tabs="productTabs"
-      :columns="productColumns"
-      :value="productValue"
-      @tab-change="handleTabChange"
-      scrollable
-      selectable
-      scroll-height="500px"
-    >
-      <template #body-coverImage="{ data }">
-        <Image
-          v-if="data.coverImage"
-          :src="data.coverImage"
-          alt="Product Cover Image"
-          imageClass="w-32 h-32 object-cover rounded mx-auto"
-          loading="lazy"
-        />
-      </template>
-      <template #body-name="{ data }">
-        <a
-          class="w-full underline text-primary cursor-pointer"
-          @click="goEditProduct(data.id)"
+  <BaseLoader :isLoading="isloading" :hasLoadedOnce="hasLoadedOnce">
+    <div v-if="!isloading">
+      <div class="flex justify-between items-center mr-8 mb-4">
+        <h2 class="text-2xl">商品</h2>
+        <div class="card flex justify-center">
+          <button
+            class="text-md text-white px-3 py-2 border-surface-200 rounded-md bg-primary cursor-pointer"
+            @click="goCreateProduct"
+          >
+            新增商品
+          </button>
+        </div>
+      </div>
+      <div class="mr-8">
+        <CommonTable
+          :tabs="productTabs"
+          :columns="productColumns"
+          :value="productValue"
+          @tab-change="handleTabChange"
+          scrollable
+          selectable
+          scroll-height="500px"
         >
-          {{ data.name }}
-        </a>
-      </template>
-    </CommonTable>
-  </div>
+          <template #body-coverImage="{ data }">
+            <Image
+              v-if="data.coverImage"
+              :src="data.coverImage"
+              alt="Product Cover Image"
+              imageClass="w-32 h-32 object-cover rounded mx-auto"
+              loading="lazy"
+            />
+          </template>
+          <template #body-name="{ data }">
+            <a
+              class="w-full underline text-primary cursor-pointer"
+              @click="goEditProduct(data.id)"
+            >
+              {{ data.name }}
+            </a>
+          </template>
+        </CommonTable>
+      </div>
+    </div>
+  </BaseLoader>
 </template>

--- a/src/views/OrderManagement.vue
+++ b/src/views/OrderManagement.vue
@@ -10,7 +10,10 @@
   import { useAuthStore } from '@/stores/auth'
   import { useStatusMap } from '@/composables/useStatusMap'
   import UserSideBar from '@/components/UserSideBar.vue'
+  import BaseLoader from '@/components/BaseLoader.vue'
 
+  const isloading = ref(true)
+  const hasLoadedOnce = ref(false)
   const { statusMap } = useStatusMap()
   const authStore = useAuthStore()
   const router = useRouter()
@@ -58,6 +61,9 @@
         statusText: statusMap[order.status],
       }))
       errorMsg.value = ''
+
+      isloading.value = false
+      hasLoadedOnce.value = true
     } catch {
       errorMsg.value = '無法取得訂單資料，請稍後再試。'
       orders.value = []
@@ -103,146 +109,154 @@
         <UserSideBar />
       </aside>
       <section class="flex-1 w-full">
-        <div v-if="authStore.isLoggedIn">
-          <div
-            class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4"
-          >
-            <h2 class="text-2xl md:text-3xl font-bold mt-4 md:mt-8">
-              我的訂單
-            </h2>
+        <BaseLoader :isLoading="isloading" :hasLoadedOnce="hasLoadedOnce">
+          <div v-if="!isloading">
+            <div v-if="authStore.isLoggedIn">
+              <div
+                class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4"
+              >
+                <h2 class="text-2xl md:text-3xl font-bold mt-4 md:mt-8">
+                  我的訂單
+                </h2>
 
-            <div class="flex flex-col md:flex-row gap-4 w-full md:w-auto">
-              <div class="flex flex-col w-full md:w-[260px]">
-                <label for="orderId" class="text-sm mb-1">訂單搜尋</label>
-                <InputText
-                  id="orderId"
-                  v-model="searchOrderId"
-                  placeholder="輸入訂單編號"
-                  class="w-full"
-                />
-              </div>
-
-              <div class="flex flex-col w-full md:w-[260px]">
-                <label for="dateRange" class="text-sm mb-1">日期</label>
-                <Select
-                  id="dateRange"
-                  v-model="selectedDateRange"
-                  :options="dateOptions"
-                  optionLabel="label"
-                  optionValue="value"
-                  placeholder="全部時間"
-                  class="w-full"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div
-            v-if="errorMsg"
-            class="mb-4 px-4 py-2 text-red-700 rounded border"
-          >
-            {{ errorMsg }}
-          </div>
-
-          <div
-            class="rounded-xl shadow border border-gray-200 overflow-x-auto bg-white"
-          >
-            <DataTable
-              v-model:expandedRows="expandedRows"
-              :value="ordersWithTotal"
-              dataKey="id"
-              expandableRows
-              class="min-w-[720px]"
-              :pt="{ bodyRow: { class: 'h-8' } }"
-            >
-              <Column expander />
-              <Column style="width: 300px">
-                <template #header>
-                  <div class="text-right pl-8 font-semibold">訂單編號</div>
-                </template>
-                <template #body="slotProps">
-                  <div class="text-left pl-4">
-                    {{ slotProps.data.orderNumber }}
-                  </div>
-                </template>
-              </Column>
-
-              <Column header="訂購日期" style="width: 260px">
-                <template #body="slotProps">
-                  <div class="text-left">
-                    {{ formatDate(slotProps.data.createdAt) }}
-                  </div>
-                </template>
-              </Column>
-
-              <Column
-                field="statusText"
-                header="狀態"
-                style="width: 260px; text-align: left"
-              />
-
-              <Column style="width: 260px">
-                <template #header>
-                  <div class="text-center font-semibold">總金額</div>
-                </template>
-                <template #body="slotProps">
-                  <div class="text-left pl-2">{{ slotProps.data.total }}</div>
-                </template>
-              </Column>
-
-              <Column header="" style="width: 200px">
-                <template #body="slotProps">
-                  <div class="flex justify-start py-1">
-                    <Button
-                      label="查看訂單"
-                      icon="pi pi-search"
-                      class="text-xs py-1 rounded shadow w-30"
-                      @click="goToDetail(slotProps.data.id)"
+                <div class="flex flex-col md:flex-row gap-4 w-full md:w-auto">
+                  <div class="flex flex-col w-full md:w-[260px]">
+                    <label for="orderId" class="text-sm mb-1">訂單搜尋</label>
+                    <InputText
+                      id="orderId"
+                      v-model="searchOrderId"
+                      placeholder="輸入訂單編號"
+                      class="w-full"
                     />
                   </div>
-                </template>
-              </Column>
 
-              <template #expansion="slotProps">
-                <div class="p-4 bg-gray-50 rounded">
-                  <h3 class="font-semibold mb-2">商品明細</h3>
-                  <ul>
-                    <li
-                      v-for="item in slotProps.data.items"
-                      :key="item.name"
-                      class="flex items-center mb-2 gap-4"
-                    >
-                      <img
-                        :src="item.productImage"
-                        alt="product"
-                        class="w-16 h-16 rounded border"
-                      />
-                      <div class="flex-1">
-                        <div class="font-medium">{{ item.productName }}</div>
-                        <div class="text-sm text-gray-600">
-                          數量：{{ item.quantity }} ｜ 售價：{{
-                            Number(item.price)
-                          }}
-                          元
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
+                  <div class="flex flex-col w-full md:w-[260px]">
+                    <label for="dateRange" class="text-sm mb-1">日期</label>
+                    <Select
+                      id="dateRange"
+                      v-model="selectedDateRange"
+                      :options="dateOptions"
+                      optionLabel="label"
+                      optionValue="value"
+                      placeholder="全部時間"
+                      class="w-full"
+                    />
+                  </div>
                 </div>
-              </template>
-            </DataTable>
-          </div>
-        </div>
+              </div>
 
-        <div v-else class="flex flex-col items-center justify-center py-24">
-          <i
-            class="pi pi-info-circle mb-4"
-            style="font-size: 1.5rem; color: #4a5568"
-          ></i>
-          <p class="mb-6 text-xl font-semibold text-gray-700">
-            請先登入會員才能查看訂單
-          </p>
-        </div>
+              <div
+                v-if="errorMsg"
+                class="mb-4 px-4 py-2 text-red-700 rounded border"
+              >
+                {{ errorMsg }}
+              </div>
+
+              <div
+                class="rounded-xl shadow border border-gray-200 overflow-x-auto bg-white"
+              >
+                <DataTable
+                  v-model:expandedRows="expandedRows"
+                  :value="ordersWithTotal"
+                  dataKey="id"
+                  expandableRows
+                  class="min-w-[720px]"
+                  :pt="{ bodyRow: { class: 'h-8' } }"
+                >
+                  <Column expander />
+                  <Column style="width: 300px">
+                    <template #header>
+                      <div class="text-right pl-8 font-semibold">訂單編號</div>
+                    </template>
+                    <template #body="slotProps">
+                      <div class="text-left pl-4">
+                        {{ slotProps.data.orderNumber }}
+                      </div>
+                    </template>
+                  </Column>
+
+                  <Column header="訂購日期" style="width: 260px">
+                    <template #body="slotProps">
+                      <div class="text-left">
+                        {{ formatDate(slotProps.data.createdAt) }}
+                      </div>
+                    </template>
+                  </Column>
+
+                  <Column
+                    field="statusText"
+                    header="狀態"
+                    style="width: 260px; text-align: left"
+                  />
+
+                  <Column style="width: 260px">
+                    <template #header>
+                      <div class="text-center font-semibold">總金額</div>
+                    </template>
+                    <template #body="slotProps">
+                      <div class="text-left pl-2">
+                        {{ slotProps.data.total }}
+                      </div>
+                    </template>
+                  </Column>
+
+                  <Column header="" style="width: 200px">
+                    <template #body="slotProps">
+                      <div class="flex justify-start py-1">
+                        <Button
+                          label="查看訂單"
+                          icon="pi pi-search"
+                          class="text-xs py-1 rounded shadow w-30"
+                          @click="goToDetail(slotProps.data.id)"
+                        />
+                      </div>
+                    </template>
+                  </Column>
+
+                  <template #expansion="slotProps">
+                    <div class="p-4 bg-gray-50 rounded">
+                      <h3 class="font-semibold mb-2">商品明細</h3>
+                      <ul>
+                        <li
+                          v-for="item in slotProps.data.items"
+                          :key="item.name"
+                          class="flex items-center mb-2 gap-4"
+                        >
+                          <img
+                            :src="item.productImage"
+                            alt="product"
+                            class="w-16 h-16 rounded border"
+                          />
+                          <div class="flex-1">
+                            <div class="font-medium">
+                              {{ item.productName }}
+                            </div>
+                            <div class="text-sm text-gray-600">
+                              數量：{{ item.quantity }} ｜ 售價：{{
+                                Number(item.price)
+                              }}
+                              元
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </template>
+                </DataTable>
+              </div>
+            </div>
+
+            <div v-else class="flex flex-col items-center justify-center py-24">
+              <i
+                class="pi pi-info-circle mb-4"
+                style="font-size: 1.5rem; color: #4a5568"
+              ></i>
+              <p class="mb-6 text-xl font-semibold text-gray-700">
+                請先登入會員才能查看訂單
+              </p>
+            </div>
+          </div>
+        </BaseLoader>
       </section>
     </div>
   </div>

--- a/src/views/ProductDetailPage.vue
+++ b/src/views/ProductDetailPage.vue
@@ -3,11 +3,11 @@
   import { useRoute, useRouter } from 'vue-router'
   import axios from '@/utils/axiosInstance'
   import Image from 'primevue/image'
-
   import Button from 'primevue/button'
   import InputNumber from 'primevue/inputnumber'
   import { useCartStore } from '@/stores/cart'
   import { showToast } from '@/utils/toast'
+  import BaseLoader from '@/components/BaseLoader.vue'
   const route = useRoute()
   const product = ref({})
   const quantity = ref(1)
@@ -15,7 +15,8 @@
   const selectedImageIndex = ref(0)
   const cart = useCartStore()
   const router = useRouter()
-
+  const isloading = ref(true)
+  const hasLoadedOnce = ref(false)
   onMounted(async () => {
     window.scrollTo(0, 0)
 
@@ -28,6 +29,9 @@
       await nextTick()
       if (!document.activeElement || document.activeElement === document.body) {
         inputRef.value?.$el?.querySelector('input')?.focus()
+
+        isloading.value = false
+        hasLoadedOnce.value = true
       }
     } catch (error) {
       if (error.response?.status === 404 || !error.response) {
@@ -124,128 +128,136 @@
 
 <template>
   <Toast />
-  <div class="max-w-screen-md mx-auto px-4 py-10 space-y-6">
-    <div class="bg-white shadow-md rounded-lg p-6 md:p-8">
-      <div class="flex flex-col md:flex-row gap-10 items-start">
-        <div class="w-full md:max-w-[460px] text-center mx-auto">
-          <div class="relative inline-block">
-            <Image
-              v-if="getCurrentImage()"
-              :src="getCurrentImage().imgUrl"
-              alt="Product Image"
-              imageClass="w-64 h-64 object-cover rounded mx-auto"
-              preview
-            />
-            <div
-              class="absolute bottom-2 right-2 bg-gray-300 bg-opacity-60 text-white text-xs px-2 py-1 rounded-[100px]"
-            >
-              {{ selectedImageIndex + 1 }} / {{ getTotalImages() }}
-            </div>
-          </div>
+  <BaseLoader :isLoading="isloading" :hasLoadedOnce="hasLoadedOnce">
+    <div v-if="!isloading">
+      <div class="max-w-screen-md mx-auto px-4 py-10 space-y-6">
+        <div class="bg-white shadow-md rounded-lg p-6 md:p-8">
+          <div class="flex flex-col md:flex-row gap-10 items-start">
+            <div class="w-full md:max-w-[460px] text-center mx-auto">
+              <div class="relative inline-block">
+                <Image
+                  v-if="getCurrentImage()"
+                  :src="getCurrentImage().imgUrl"
+                  alt="Product Image"
+                  imageClass="w-64 h-64 object-cover rounded mx-auto"
+                  preview
+                />
+                <div
+                  class="absolute bottom-2 right-2 bg-gray-300 bg-opacity-60 text-white text-xs px-2 py-1 rounded-[100px]"
+                >
+                  {{ selectedImageIndex + 1 }} / {{ getTotalImages() }}
+                </div>
+              </div>
 
-          <div v-if="product.images" class="flex justify-center gap-2 mt-4">
-            <div
-              class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
-              :class="{
-                'border-blue-500': selectedImageIndex === 0,
-                'border-gray-300': selectedImageIndex !== 0,
-              }"
-              @click="selectImage(0)"
-            >
-              <img
-                :src="product.images.cover.imgUrl"
-                alt="Cover thumbnail"
-                class="w-full h-full object-cover"
-              />
+              <div v-if="product.images" class="flex justify-center gap-2 mt-4">
+                <div
+                  class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
+                  :class="{
+                    'border-blue-500': selectedImageIndex === 0,
+                    'border-gray-300': selectedImageIndex !== 0,
+                  }"
+                  @click="selectImage(0)"
+                >
+                  <img
+                    :src="product.images.cover.imgUrl"
+                    alt="Cover thumbnail"
+                    class="w-full h-full object-cover"
+                  />
+                </div>
+
+                <div
+                  v-for="(image, index) in product.images.previews || []"
+                  :key="image.id"
+                  class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
+                  :class="{
+                    'border-blue-500': selectedImageIndex === index + 1,
+                    'border-gray-300': selectedImageIndex !== index + 1,
+                  }"
+                  @click="selectImage(index + 1)"
+                >
+                  <img
+                    :src="image.imgUrl"
+                    :alt="`Preview thumbnail ${index + 1}`"
+                    class="w-full h-full object-cover"
+                  />
+                </div>
+              </div>
             </div>
 
             <div
-              v-for="(image, index) in product.images.previews || []"
-              :key="image.id"
-              class="w-16 h-16 border-2 rounded cursor-pointer overflow-hidden"
-              :class="{
-                'border-blue-500': selectedImageIndex === index + 1,
-                'border-gray-300': selectedImageIndex !== index + 1,
-              }"
-              @click="selectImage(index + 1)"
+              class="w-full md:max-w-[360px] mx-auto flex flex-col space-y-4"
             >
-              <img
-                :src="image.imgUrl"
-                :alt="`Preview thumbnail ${index + 1}`"
-                class="w-full h-full object-cover"
-              />
+              <h1 class="text-xl sm:text-2xl font-bold leading-snug text-black">
+                {{ product.name }}
+              </h1>
+
+              <div class="text-lg sm:text-xl text-black font-bold">
+                <span
+                  :class="{
+                    'line-through text-gray-400': product.discountPrice,
+                  }"
+                >
+                  ${{ product.price }}
+                </span>
+              </div>
+
+              <div class="flex items-center gap-3">
+                <label for="quantity" class="text-black text-sm">數量</label>
+                <InputNumber
+                  v-model="quantity"
+                  :ref="inputRef"
+                  inputId="quantity"
+                  :min="1"
+                  showButtons
+                  buttonLayout="horizontal"
+                  decrementButtonClass="p-button-text !h-8 !w-8"
+                  incrementButtonClass="p-button-text !h-8 !w-8"
+                  inputClass="text-center w-12 h-8 text-sm"
+                  class="text-sm"
+                >
+                  <template #incrementicon>
+                    <i class="pi pi-plus text-xs" />
+                  </template>
+                  <template #decrementicon>
+                    <i class="pi pi-minus text-xs" />
+                  </template>
+                </InputNumber>
+              </div>
+
+              <div class="flex gap-3 mt-1">
+                <Button
+                  label="加入購物車"
+                  icon="pi pi-shopping-cart"
+                  class="flex-1"
+                  @click="addToCart"
+                />
+                <Button
+                  :label="product.isFavorited ? '已收藏' : '收藏'"
+                  class="flex-1 flex items-center justify-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-black border-none"
+                  @click="toggleFavorite"
+                >
+                  <template #icon>
+                    <i
+                      :class="[
+                        product.isFavorited
+                          ? 'pi pi-heart-fill text-red-500'
+                          : 'pi pi-heart text-white',
+                        'text-xl',
+                      ]"
+                    />
+                  </template>
+                </Button>
+              </div>
             </div>
           </div>
         </div>
 
-        <div class="w-full md:max-w-[360px] mx-auto flex flex-col space-y-4">
-          <h1 class="text-xl sm:text-2xl font-bold leading-snug text-black">
-            {{ product.name }}
-          </h1>
-
-          <div class="text-lg sm:text-xl text-black font-bold">
-            <span
-              :class="{ 'line-through text-gray-400': product.discountPrice }"
-            >
-              ${{ product.price }}
-            </span>
-          </div>
-
-          <div class="flex items-center gap-3">
-            <label for="quantity" class="text-black text-sm">數量</label>
-            <InputNumber
-              v-model="quantity"
-              :ref="inputRef"
-              inputId="quantity"
-              :min="1"
-              showButtons
-              buttonLayout="horizontal"
-              decrementButtonClass="p-button-text !h-8 !w-8"
-              incrementButtonClass="p-button-text !h-8 !w-8"
-              inputClass="text-center w-12 h-8 text-sm"
-              class="text-sm"
-            >
-              <template #incrementicon>
-                <i class="pi pi-plus text-xs" />
-              </template>
-              <template #decrementicon>
-                <i class="pi pi-minus text-xs" />
-              </template>
-            </InputNumber>
-          </div>
-
-          <div class="flex gap-3 mt-1">
-            <Button
-              label="加入購物車"
-              icon="pi pi-shopping-cart"
-              class="flex-1"
-              @click="addToCart"
-            />
-            <Button
-              :label="product.isFavorited ? '已收藏' : '收藏'"
-              class="flex-1 flex items-center justify-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-black border-none"
-              @click="toggleFavorite"
-            >
-              <template #icon>
-                <i
-                  :class="[
-                    product.isFavorited
-                      ? 'pi pi-heart-fill text-red-500'
-                      : 'pi pi-heart text-white',
-                    'text-xl',
-                  ]"
-                />
-              </template>
-            </Button>
-          </div>
+        <div
+          class="bg-white shadow-md rounded-lg p-6 text-black text-base sm:text-lg leading-relaxed"
+        >
+          <div v-html="product.description"></div>
         </div>
       </div>
     </div>
-
-    <div
-      class="bg-white shadow-md rounded-lg p-6 text-black text-base sm:text-lg leading-relaxed"
-    >
-      <div v-html="product.description"></div>
-    </div>
-  </div>
+  </BaseLoader>
 </template>


### PR DESCRIPTION
- `UserSideBar` 訂單中心的 icon 改成跟 NavBar 下拉一樣的 icon
<img width="278" alt="image" src="https://github.com/user-attachments/assets/b58d922d-8173-465f-82be-16b252807fb7" />


- 上次請子毅寫 token 過期後自動登出，但 token 失效重整畫面後，`isLoggedIn` 未初始化完成，依然會先判斷為登入狀態，就先 `fetchCart` 了所以還是會跳購物車載入失敗 toast ：
  - 新增 auth initialize，確保 auth 狀態先初始化完成，就不會跳購物車 toast 了


- 修改 `BaseLoader` 邏輯並套用在後台三個列表、單一商品頁、訂單中心頁
  - 原邏輯沒有寫 load 完之後要顯示該頁面主要內容，導致轉圈圈轉完之後，畫面沒有渲染出來