### PR TITLE
fix: 移除google登入成功後的showtoast detail 

### DIFF
--- a/src/views/AuthForm.vue
+++ b/src/views/AuthForm.vue
@@ -48,7 +48,6 @@
         showToast({
           severity: 'success',
           summary: 'Google 登入成功',
-          detail: `歡迎回來，${payload.username}！`,
         })
 
         authStore.login(token, payload.role || 'user')


### PR DESCRIPTION
- 移除show toast detail訊息
- 因google登入是打到部署的網址，因此要合併後才會有效果