### PR TITLE
先不合 fix:  全站加入 cache 讓商品頁不用每次都載入很久

### DIFF
--- a/src/api/product.js
+++ b/src/api/product.js
@@ -1,8 +1,8 @@
 import axios from '@/utils/axiosInstance'
 
-const fetchAllProducts = async (status = 'all') => {
+const fetchAllProducts = async (status = 'all', page = 1, limit = 20) => {
   const res = await axios.get('/admin/products', {
-    params: { status },
+    params: { status, page, limit },
   })
   return res.data
 }

--- a/src/components/AdminSearchBar.vue
+++ b/src/components/AdminSearchBar.vue
@@ -10,11 +10,12 @@
 
   onMounted(async () => {
     const [productRes, orderRes] = await Promise.all([
-      fetchAllProducts(),
+      fetchAllProducts('all', 1, 1000),
       fetchOrders(),
     ])
 
-    const productItems = productRes.map((product) => ({
+    const products = productRes.data || productRes
+    const productItems = products.map((product) => ({
       id: product.id,
       label: product.name,
       code: product.sku,

--- a/src/components/BaseLoader.vue
+++ b/src/components/BaseLoader.vue
@@ -5,18 +5,6 @@
   })
 </script>
 
-<!-- <template>
-  <div
-    v-if="!hasLoadedOnce || isLoading"
-    class="text-center text-gray-500 py-10"
-  >
-    <i class="pi pi-spin pi-spinner text-2xl mb-2"></i>
-    <slot>
-      <p>載入中...</p>
-    </slot>
-  </div>
-</template> -->
-
 <template>
   <div
     v-if="isLoading || !hasLoadedOnce"

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -29,12 +29,21 @@
       type: Array,
       required: true,
     },
+    pagination: {
+      type: Object,
+      default: null,
+    },
     scrollable: { type: Boolean, default: true },
     scrollHeight: { type: String, default: '500px' },
     selectable: { type: Boolean, default: true },
   })
 
-  const emit = defineEmits(['tab-change'])
+  const emit = defineEmits(['tab-change', 'page-change'])
+
+  const handlePageChange = (event) => {
+    const page = event.page + 1
+    emit('page-change', page)
+  }
 </script>
 
 <template>
@@ -55,9 +64,12 @@
               data-key="id"
               scrollable
               scroll-height="500px"
-              paginator
-              :rows="20"
-              :rowsPerPageOptions="[5, 10, 20, 50]"
+              :paginator="!!pagination"
+              :rows="pagination?.limit || 20"
+              :totalRecords="pagination?.totalCount || filteredData.length"
+              :first="pagination ? (pagination.currentPage - 1) * pagination.limit : 0"
+              :lazy="!!pagination"
+              @page="handlePageChange"
             >
               <Column
                 selection-mode="multiple"

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -8,14 +8,6 @@
   import Column from 'primevue/column'
   import { ref, computed } from 'vue'
 
-  const selectedRows = ref([])
-  const activeTab = ref('all')
-  const filteredData = computed(() => {
-    return activeTab.value === 'all'
-      ? props.value
-      : props.value.filter((item) => item.status === activeTab.value)
-  })
-
   const props = defineProps({
     tabs: {
       type: Array,
@@ -36,31 +28,52 @@
     scrollable: { type: Boolean, default: true },
     scrollHeight: { type: String, default: '500px' },
     selectable: { type: Boolean, default: true },
+    activeTab: {
+      type: String,
+      default: 'all',
+    },
   })
 
-  const emit = defineEmits(['tab-change', 'page-change'])
+  const selectedRows = ref([])
+  const filteredData = computed(() => {
+    return props.activeTab === 'all'
+      ? props.value
+      : props.value.filter((item) => item.status === props.activeTab)
+  })
+
+  const emit = defineEmits(['tab-change', 'page-change', 'sort'])
+
+  const handleTabChange = (value) => {
+    const tab = props.tabs.find((t) => t.value === value)
+    emit('tab-change', tab || { value })
+  }
 
   const handlePageChange = (event) => {
     const page = event.page + 1
     emit('page-change', page)
   }
+
+  const handleSort = (event) => {
+    emit('sort', event)
+  }
 </script>
 
 <template>
   <div class="card">
-    <Tabs v-model:value="activeTab" @update:value="emit('tab-change', $event)">
+    <Tabs :value="props.activeTab" @update:value="handleTabChange">
       <TabList>
-        <Tab v-for="tab in tabs" :key="tab.title" :value="tab.value">
+        <Tab v-for="tab in props.tabs" :key="tab.title" :value="tab.value">
           {{ tab.title }}
         </Tab>
       </TabList>
       <TabPanels>
-        <TabPanel v-for="tab in tabs" :key="tab.value" :value="tab.value">
+        <TabPanel v-for="tab in props.tabs" :key="tab.value" :value="tab.value">
           <div class="card">
             <DataTable
               v-model:selection="selectedRows"
               :value="filteredData"
               removable-sort
+              sort-mode="single"
               data-key="id"
               scrollable
               scroll-height="500px"
@@ -72,13 +85,14 @@
               "
               :lazy="!!pagination"
               @page="handlePageChange"
+              @sort="handleSort"
             >
               <Column
                 selection-mode="multiple"
                 header-style="width: 3rem"
               ></Column>
               <Column
-                v-for="col in columns"
+                v-for="col in props.columns"
                 :key="col.field"
                 :field="col.field"
                 :header="col.header"

--- a/src/components/CommonTable.vue
+++ b/src/components/CommonTable.vue
@@ -67,7 +67,9 @@
               :paginator="!!pagination"
               :rows="pagination?.limit || 20"
               :totalRecords="pagination?.totalCount || filteredData.length"
-              :first="pagination ? (pagination.currentPage - 1) * pagination.limit : 0"
+              :first="
+                pagination ? (pagination.currentPage - 1) * pagination.limit : 0
+              "
               :lazy="!!pagination"
               @page="handlePageChange"
             >

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -6,6 +6,10 @@
 
   const props = defineProps({
     product: Object,
+    index: {
+      type: Number,
+      default: 0,
+    },
   })
 
   async function addToCart(e) {
@@ -44,6 +48,9 @@
       :src="product.coverImage"
       alt="商品圖片"
       class="w-full h-64 object-contain bg-white"
+      :loading="index < 6 ? 'eager' : 'lazy'"
+      :fetchpriority="index < 3 ? 'high' : 'auto'"
+      decoding="async"
     />
     <div class="p-4">
       <p

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -91,8 +91,10 @@ export function useProductList() {
         products.value = []
         isLoading.value = true
         try {
-          const res = await axios.get('/products')
-          products.value = res.data
+          const res = await axios.get('/products', {
+            params: { limit: 200 }
+          })
+          products.value = res.data?.data || res.data || []
         } catch {
           products.value = []
         } finally {
@@ -116,14 +118,16 @@ export function useProductList() {
 
   const products = ref([])
 
-  const loadProductsByCategory = async (category) => {
+  const loadProductsByCategory = async (category, page = 1) => {
     products.value = []
     isLoading.value = true
 
     try {
       if (category === '全部') {
-        const res = await axios.get('/products')
-        products.value = res.data
+        const res = await axios.get('/products', {
+          params: { page, limit: 200 }
+        })
+        products.value = res.data?.data || res.data || []
       } else {
         const res = await axios.get('/tags/filterByTagnames', {
           params: { tagname: category },
@@ -138,7 +142,7 @@ export function useProductList() {
     }
   }
 
-  const loadProductsByIpTag = async (ipTag) => {
+  const loadProductsByIpTag = async (ipTag, page = 1) => {
     products.value = []
     isLoading.value = true
 
@@ -149,8 +153,10 @@ export function useProductList() {
         })
         products.value = res.data.products || []
       } else {
-        const res = await axios.get('/products')
-        products.value = res.data
+        const res = await axios.get('/products', {
+          params: { page, limit: 200 }
+        })
+        products.value = res.data?.data || res.data || []
       }
     } catch {
       products.value = []

--- a/src/composables/useProductList.js
+++ b/src/composables/useProductList.js
@@ -3,6 +3,20 @@ import axios from '@/utils/axiosInstance'
 import { useRoute, useRouter } from 'vue-router'
 import { fetchFilterData } from '@/api/product'
 
+const globalCache = new Map()
+const cacheExpiry = 10 * 60 * 1000
+
+const cleanupExpiredCache = () => {
+  const now = Date.now()
+  for (const [key, value] of globalCache.entries()) {
+    if (now - value.timestamp > cacheExpiry) {
+      globalCache.delete(key)
+    }
+  }
+}
+
+setInterval(cleanupExpiredCache, cacheExpiry)
+
 export function useProductList() {
   const route = useRoute()
   const router = useRouter()
@@ -19,8 +33,7 @@ export function useProductList() {
     try {
       const res = await axios.get('/products/random?limit=8')
       randomProducts.value = res.data
-    } catch (err) {
-      err
+    } catch {
       randomProducts.value = []
     }
   }
@@ -92,7 +105,7 @@ export function useProductList() {
         isLoading.value = true
         try {
           const res = await axios.get('/products', {
-            params: { limit: 200 }
+            params: { limit: 200 },
           })
           products.value = res.data?.data || res.data || []
         } catch {
@@ -118,22 +131,41 @@ export function useProductList() {
 
   const products = ref([])
 
+  const getCacheKey = (category, page = 1) => `${category}-${page}`
+
   const loadProductsByCategory = async (category, page = 1) => {
+    const cacheKey = getCacheKey(category, page)
+    const cached = globalCache.get(cacheKey)
+
+    if (cached && Date.now() - cached.timestamp < cacheExpiry) {
+      products.value = cached.data
+      hasLoadedOnce.value = true
+      return
+    }
+
     products.value = []
     isLoading.value = true
 
     try {
+      let data = []
       if (category === '全部') {
         const res = await axios.get('/products', {
-          params: { page, limit: 200 }
+          params: { page, limit: 200 },
         })
-        products.value = res.data?.data || res.data || []
+        data = res.data?.data || res.data || []
       } else {
         const res = await axios.get('/tags/filterByTagnames', {
           params: { tagname: category },
         })
-        products.value = res.data.products || []
+        data = res.data.products || []
       }
+
+      products.value = data
+
+      globalCache.set(cacheKey, {
+        data,
+        timestamp: Date.now(),
+      })
     } catch {
       products.value = []
     } finally {
@@ -143,21 +175,37 @@ export function useProductList() {
   }
 
   const loadProductsByIpTag = async (ipTag, page = 1) => {
+    const cacheKey = getCacheKey(`ip-${ipTag}`, page)
+    const cached = globalCache.get(cacheKey)
+
+    if (cached && Date.now() - cached.timestamp < cacheExpiry) {
+      products.value = cached.data
+      hasLoadedOnce.value = true
+      return
+    }
+
     products.value = []
     isLoading.value = true
 
     try {
+      let data = []
       if (ipTag) {
         const res = await axios.get('/tags/filterByTagnames', {
           params: { tagname: ipTag },
         })
-        products.value = res.data.products || []
+        data = res.data.products || []
       } else {
         const res = await axios.get('/products', {
-          params: { page, limit: 200 }
+          params: { page, limit: 200 },
         })
-        products.value = res.data?.data || res.data || []
+        data = res.data?.data || res.data || []
       }
+
+      products.value = data
+      globalCache.set(cacheKey, {
+        data,
+        timestamp: Date.now(),
+      })
     } catch {
       products.value = []
     } finally {

--- a/src/utils/orderUtils.js
+++ b/src/utils/orderUtils.js
@@ -1,0 +1,21 @@
+/**
+ * 從訂單編號中提取時間戳
+ * @param {string} orderNumber - 訂單編號 (格式: ORDER-時間戳-隨機字串)
+ * @returns {number} 時間戳，如果無法解析則返回 0
+ */
+export const getOrderTimestamp = (orderNumber) => {
+  const match = orderNumber.match(/ORDER-(\d+)-/)
+  return match ? parseInt(match[1]) : 0
+}
+
+/**
+ * 按訂單編號中的時間戳進行降冪排序
+ * @param {Array} orders - 訂單陣列
+ * @returns {Array} 排序後的訂單陣列（最新的在前面）
+ */
+export const sortOrdersByTimestamp = (orders) => {
+  return orders.sort(
+    (a, b) =>
+      getOrderTimestamp(b.orderNumber) - getOrderTimestamp(a.orderNumber)
+  )
+}

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -104,6 +104,7 @@
         :columns="inventoryColumns"
         :value="productValue"
         :pagination="pagination"
+        :active-tab="currentStatus"
         @tab-change="handleTabChange"
         @page-change="handlePageChange"
         scrollable

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -50,7 +50,7 @@
     totalCount: 0,
     limit: 20,
     hasNextPage: false,
-    hasPreviousPage: false
+    hasPreviousPage: false,
   })
   const currentStatus = ref('all')
 
@@ -65,7 +65,7 @@
         totalCount: 0,
         limit: 20,
         hasNextPage: false,
-        hasPreviousPage: false
+        hasPreviousPage: false,
       }
       currentStatus.value = status
     } catch {

--- a/src/views/Admin/AdminInventory.vue
+++ b/src/views/Admin/AdminInventory.vue
@@ -44,14 +44,51 @@
     },
   ])
   const productValue = ref([])
+  const pagination = ref({
+    currentPage: 1,
+    totalPages: 0,
+    totalCount: 0,
+    limit: 20,
+    hasNextPage: false,
+    hasPreviousPage: false
+  })
+  const currentStatus = ref('all')
+
+  const loadProducts = async (status = 'all', page = 1) => {
+    isloading.value = true
+    try {
+      const res = await fetchAllProducts(status, page, pagination.value.limit)
+      productValue.value = res.data || []
+      pagination.value = res.pagination || {
+        currentPage: 1,
+        totalPages: 0,
+        totalCount: 0,
+        limit: 20,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }
+      currentStatus.value = status
+    } catch {
+      productValue.value = []
+    } finally {
+      isloading.value = false
+    }
+  }
+
+  const handleTabChange = async (tab) => {
+    await loadProducts(tab.value, 1)
+  }
+
   const goStockLog = (id) => {
     router.push({ name: 'stockLog', params: { id } })
   }
 
+  const handlePageChange = async (page) => {
+    await loadProducts(currentStatus.value, page)
+  }
+
   onMounted(async () => {
-    const res = await fetchAllProducts()
-    productValue.value = res
-    isloading.value = false
+    await loadProducts()
     hasLoadedOnce.value = true
   })
 </script>
@@ -66,6 +103,9 @@
         :tabs="inventoryTabs"
         :columns="inventoryColumns"
         :value="productValue"
+        :pagination="pagination"
+        @tab-change="handleTabChange"
+        @page-change="handlePageChange"
         scrollable
         selectable
         scroll-height="500px"

--- a/src/views/Admin/AdminOrders.vue
+++ b/src/views/Admin/AdminOrders.vue
@@ -6,6 +6,7 @@
   import CommonTable from '@/components/CommonTable.vue'
   import { showToast } from '@/utils/toast'
   import BaseLoader from '@/components/BaseLoader.vue'
+  import { sortOrdersByTimestamp } from '@/utils/orderUtils'
   const router = useRouter()
   const isloading = ref(true)
   const hasLoadedOnce = ref(false)
@@ -71,11 +72,11 @@
     },
   ])
   const currentStatus = ref('all')
-  const handleTabChange = async (newStatus) => {
-    currentStatus.value = newStatus
+  const handleTabChange = async (tab) => {
+    currentStatus.value = tab.value
     try {
-      const res = await fetchAllOrders(newStatus)
-      orderValue.value = res
+      const res = await fetchAllOrders(tab.value)
+      orderValue.value = sortOrdersByTimestamp(res)
     } catch {
       showToast({
         severity: 'warn',
@@ -88,7 +89,7 @@
   const orderValue = ref([])
   onMounted(async () => {
     const res = await fetchAllOrders()
-    orderValue.value = res
+    orderValue.value = sortOrdersByTimestamp(res)
     isloading.value = false
     hasLoadedOnce.value = true
   })
@@ -106,6 +107,7 @@
           :tabs="orderTabs"
           :columns="orderColumns"
           :value="orderValue"
+          :active-tab="currentStatus"
           @tab-change="handleTabChange"
           scrollable
           selectable

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -19,12 +19,12 @@
   ])
   const productColumns = ref([
     { field: 'coverImage', header: '', style: 'width: 25%', sortable: false },
-    { field: 'name', header: '商品', style: 'width: 25%', sortable: true },
+    { field: 'name', header: '商品', style: 'width: 25%', sortable: false },
     {
       field: 'status',
       header: '狀態',
       style: 'width: 25%',
-      sortable: true,
+      sortable: false,
       format: (val) =>
         ({
           active: '上架中',
@@ -62,6 +62,7 @@
   }
 
   const handleTabChange = async (tab) => {
+    currentStatus.value = tab.value
     await loadProducts(tab.value, 1)
   }
 
@@ -86,6 +87,30 @@
 
   const handlePageChange = async (page) => {
     await loadProducts(currentStatus.value, page)
+  }
+
+  const handleSort = (event) => {
+    const { sortField, sortOrder } = event
+    if (sortField && sortOrder) {
+      productValue.value.sort((a, b) => {
+        let aVal = a[sortField]
+        let bVal = b[sortField]
+
+        // 處理數字類型
+        if (sortField === 'stockOnHand') {
+          aVal = Number(aVal) || 0
+          bVal = Number(bVal) || 0
+        }
+
+        if (sortOrder === 1) {
+          // 升序
+          return aVal > bVal ? 1 : aVal < bVal ? -1 : 0
+        } else {
+          // 降序
+          return aVal < bVal ? 1 : aVal > bVal ? -1 : 0
+        }
+      })
+    }
   }
 
   onMounted(async () => {
@@ -115,8 +140,10 @@
           :columns="productColumns"
           :value="productValue"
           :pagination="pagination"
+          :active-tab="currentStatus"
           @tab-change="handleTabChange"
           @page-change="handlePageChange"
+          @sort="handleSort"
           scrollable
           selectable
           scroll-height="500px"

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -51,7 +51,7 @@
         totalCount: 0,
         limit: 20,
         hasNextPage: false,
-        hasPreviousPage: false
+        hasPreviousPage: false,
       }
       currentStatus.value = status
     } catch {
@@ -72,7 +72,7 @@
     totalCount: 0,
     limit: 20,
     hasNextPage: false,
-    hasPreviousPage: false
+    hasPreviousPage: false,
   })
   const currentStatus = ref('all')
 

--- a/src/views/Admin/AdminProducts.vue
+++ b/src/views/Admin/AdminProducts.vue
@@ -40,12 +40,41 @@
     },
   ])
 
+  const loadProducts = async (status = 'all', page = 1) => {
+    isloading.value = true
+    try {
+      const res = await fetchAllProducts(status, page, pagination.value.limit)
+      productValue.value = res.data || []
+      pagination.value = res.pagination || {
+        currentPage: 1,
+        totalPages: 0,
+        totalCount: 0,
+        limit: 20,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }
+      currentStatus.value = status
+    } catch {
+      productValue.value = []
+    } finally {
+      isloading.value = false
+    }
+  }
+
   const handleTabChange = async (tab) => {
-    const res = await fetchAllProducts(tab.value)
-    productValue.value = res
+    await loadProducts(tab.value, 1)
   }
 
   const productValue = ref([])
+  const pagination = ref({
+    currentPage: 1,
+    totalPages: 0,
+    totalCount: 0,
+    limit: 20,
+    hasNextPage: false,
+    hasPreviousPage: false
+  })
+  const currentStatus = ref('all')
 
   const goCreateProduct = () => {
     router.push({ name: 'createProduct' })
@@ -55,10 +84,12 @@
     router.push({ name: 'editProduct', params: { id } })
   }
 
+  const handlePageChange = async (page) => {
+    await loadProducts(currentStatus.value, page)
+  }
+
   onMounted(async () => {
-    const res = await fetchAllProducts()
-    productValue.value = res
-    isloading.value = false
+    await loadProducts()
     hasLoadedOnce.value = true
   })
 </script>
@@ -83,7 +114,9 @@
           :tabs="productTabs"
           :columns="productColumns"
           :value="productValue"
+          :pagination="pagination"
           @tab-change="handleTabChange"
+          @page-change="handlePageChange"
           scrollable
           selectable
           scroll-height="500px"

--- a/src/views/Admin/stockLog.vue
+++ b/src/views/Admin/stockLog.vue
@@ -249,10 +249,17 @@
         >
           <template #body="{ data }">
             {{
-              new Date(data.createdAt)
-                .toISOString()
-                .replace('T', ' ')
-                .slice(0, 19)
+              data.createdAt
+                ? new Date(data.createdAt).toLocaleString('zh-TW', {
+                    timeZone: 'Asia/Taipei',
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: false,
+                  })
+                : '—'
             }}
           </template>
         </Column>

--- a/src/views/OrderManagement.vue
+++ b/src/views/OrderManagement.vue
@@ -11,6 +11,7 @@
   import { useStatusMap } from '@/composables/useStatusMap'
   import UserSideBar from '@/components/UserSideBar.vue'
   import BaseLoader from '@/components/BaseLoader.vue'
+  import { sortOrdersByTimestamp } from '@/utils/orderUtils'
 
   const isloading = ref(true)
   const hasLoadedOnce = ref(false)
@@ -56,7 +57,9 @@
       }
 
       const data = await fetchOrders(filters)
-      orders.value = data.map((order) => ({
+      const sortedData = sortOrdersByTimestamp(data)
+
+      orders.value = sortedData.map((order) => ({
         ...order,
         statusText: statusMap[order.status],
       }))

--- a/src/views/ProductListPage.vue
+++ b/src/views/ProductListPage.vue
@@ -94,12 +94,12 @@
             class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 min-w-0"
           >
             <RouterLink
-              v-for="item in paginatedProducts"
+              v-for="(item, index) in paginatedProducts"
               :key="item.id"
               :to="`/products/${item.id}`"
               class="block"
             >
-              <ProductCard :product="item" />
+              <ProductCard :product="item" :index="index" />
             </RouterLink>
           </div>
 

--- a/src/volt/DataTable.vue
+++ b/src/volt/DataTable.vue
@@ -6,6 +6,13 @@
     :ptOptions="{
       mergeProps: ptViewMerge,
     }"
+    v-bind="$attrs"
+    @sort="(event) => $emit('sort', event)"
+    @page="(event) => $emit('page', event)"
+    @row-click="(event) => $emit('rowClick', event)"
+    @row-select="(event) => $emit('rowSelect', event)"
+    @row-unselect="(event) => $emit('rowUnselect', event)"
+    @select-all-change="(event) => $emit('selectAllChange', event)"
   >
     <template
       #paginatorcontainer="{
@@ -100,8 +107,20 @@
   import SecondaryButton from './SecondaryButton.vue'
   import { ptViewMerge } from './utils'
 
+  defineOptions({
+    inheritAttrs: false,
+  })
+
   interface Props extends /* @vue-ignore */ DataTableProps {}
   defineProps<Props>()
+  defineEmits([
+    'sort',
+    'page',
+    'rowClick',
+    'rowSelect',
+    'rowUnselect',
+    'selectAllChange',
+  ])
 
   const theme = ref<DataTablePassThroughOptions>({
     root: `relative p-flex-scrollable:flex p-flex-scrollable:flex-col p-flex-scrollable:h-full`,


### PR DESCRIPTION
### 變更內容
- 新增全站快取，快取保留十分鐘。包含單一商品頁面和 tag 點擊後的頁面
- 後台商品列表跟庫存列表一次載入 20筆，不會載很久

### 修改原因
- 提升商品頁使用者體驗，讓用戶不用一直等待載入商品
- 後台也不用等 loading 很久

### 驗證方式
1. `npm run dev` 開啟本地伺服器
2. 後端切往同分支
3. 確認載入商品跟返回都很快速 💨